### PR TITLE
allow yml files for groups

### DIFF
--- a/lib/interferon/group_sources/filesystem.rb
+++ b/lib/interferon/group_sources/filesystem.rb
@@ -18,7 +18,7 @@ module Interferon::GroupSources
           next
         end
 
-        Dir.glob(File.join(path, '*.{json,yaml}')) do |group_file|
+        Dir.glob(File.join(path, '*.{json,yml,yaml}')) do |group_file|
           begin
             group = YAML::parse(File.read(group_file))
           rescue YAML::SyntaxError => e


### PR DESCRIPTION
This allows for the `.yml` extension in addition to the `.yaml` extension to work with group files.

## Test plan
I ran `bundle exec interferon --config config.example.yaml` and got output with `.yml` files included:
```
I, [2015-11-06T10:58:35.628259 #16313]  INFO -- Interferon::Interferon: beginning alerts run
I, [2015-11-06T10:58:35.634002 #16313]  INFO -- Interferon::Interferon: read 362 alerts files from /Users/alvin/work/alerts/alerts
D, [2015-11-06T10:58:35.634662 #16313] DEBUG -- Interferon::GroupSourcesLoader: LoadError looking for group source file filesystem at /Users/alvin/work/alerts/group_sources/filesystem: cannot load such file -- /Users/alvin/work/alerts/group_sources/filesystem
I, [2015-11-06T10:58:35.638177 #16313]  INFO -- Interferon::Interferon: read 215 people in 30 groups from source Interferon::GroupSources::Filesystem
I, [2015-11-06T10:58:35.638238 #16313]  INFO -- Interferon::Interferon: total of 215 people in 30 groups from 1 sources
I, [2015-11-06T10:58:35.638407 #16313]  INFO -- Interferon::HostSourcesLoader: skipping host source aws_rds because it's not enabled
I, [2015-11-06T10:58:35.638434 #16313]  INFO -- Interferon::HostSourcesLoader: skipping host source aws_dynamo because it's not enabled
I, [2015-11-06T10:58:35.638448 #16313]  INFO -- Interferon::HostSourcesLoader: skipping host source aws_elasticache because it's not enabled
I, [2015-11-06T10:58:35.638462 #16313]  INFO -- Interferon::Interferon: total of 0 entities from 3 sources
```

@igor47 