### PR TITLE
split a long method into multiple ones

### DIFF
--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
No logic change, simply splits the update_alerts into multiple sub methods for code reuse purpose.
@igor47 @wyao