### PR TITLE
method need return value in graceful shutdown

### DIFF
--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -198,8 +198,8 @@ module Interferon
           t
         end
         threads.map(&:join)
-        alert_keys
       end
+      return alert_keys
     end
 
     def build_alerts_queue(hosts, alerts, groups)

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.8"
+  VERSION = "0.0.8.1"
 end


### PR DESCRIPTION
In v0.0.8 `create_alerts` does not return value in grace shutdown mode, which will crash the program.

to @igor47 @jianAir 