### PR TITLE
Enable dry run to hit datadog api

### DIFF
--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -173,7 +173,7 @@ module Interferon
       unless @request_shutdown
         # run time summary
         run_time = Time.new.to_f - start_time
-        statsd.histogram('destinations.run_time', run_time, :tags => ["destination:#{dest.class.name}", "dry_run:true"])
+        statsd.histogram('destinations.run_time_dry_run', run_time, :tags => ["destination:#{dest.class.name}"])
         log.info "#{dest.class.name} : dry run completed in %.2f seconds" % (run_time)
 
         # report destination stats
@@ -212,7 +212,7 @@ module Interferon
       unless @request_shutdown
         # run time summary
         run_time = Time.new.to_f - start_time
-        statsd.histogram('destinations.run_time', run_time, :tags => ["destination:#{dest.class.name}", "dry_run:false"])
+        statsd.histogram('destinations.run_time', run_time, :tags => ["destination:#{dest.class.name}"])
         log.info "#{dest.class.name} : run completed in %.2f seconds" % (run_time)
 
         # report destination stats

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -243,8 +243,8 @@ module Interferon
           t
         end
         threads.map(&:join)
-        alert_key_ids
       end
+      alert_key_ids
     end
 
     def build_alerts_queue(hosts, alerts, groups)

--- a/lib/interferon/alert.rb
+++ b/lib/interferon/alert.rb
@@ -22,6 +22,14 @@ module Interferon
       self
     end
 
+    def change_name(name)
+      unless @dsl
+        raise "This alert has not yet been evaluated"
+      end
+
+      @dsl.name(name)
+    end
+
     def [](attr)
       unless @dsl
         raise "This alert has not yet been evaluated"

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -174,6 +174,7 @@ module Interferon::Destinations
     def remove_alert_by_id(alert_id)
       log.debug("deleting alert, id: #{alert_id}")
       @dog.delete_alert(alert_id)
+      @stats[:alerts_deleted] += 1
     end
   end
 end

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -35,7 +35,6 @@ module Interferon::Destinations
 
     def api_errors
       @api_errors ||= []
-      @api_errors
     end
 
     def existing_alerts
@@ -109,7 +108,7 @@ module Interferon::Destinations
       # log whenever we've encountered errors
       code = resp[0].to_i
       if code != 200
-        @api_errors << "#{code.to_s} on alert #{alert['name']}"
+        api_errors << "#{code.to_s} on alert #{alert['name']}"
       end
 
       # client error

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -16,7 +16,6 @@ module Interferon::Destinations
       end
 
       @dog = Dogapi::Client.new(options['api_key'], options['app_key'])
-      @dry_run = !!options['dry_run']
       @existing_alerts = nil
 
       # create datadog alerts 10 at a time
@@ -32,6 +31,11 @@ module Interferon::Destinations
         :api_unknown_errors => 0,
         :manually_created_alerts => 0,
       }
+    end
+
+    def api_errors
+      @api_errors ||= []
+      @api_errors
     end
 
     def existing_alerts
@@ -87,7 +91,7 @@ module Interferon::Destinations
         resp = @dog.alert(
           alert['metric']['datadog_query'].strip,
           alert_opts,
-        ) unless @dry_run
+        )
 
       # existing alert, modify it
       else
@@ -99,11 +103,14 @@ module Interferon::Destinations
           id,
           alert['metric']['datadog_query'].strip,
           alert_opts
-        ) unless @dry_run
+        )
       end
 
       # log whenever we've encountered errors
-      code = @dry_run ? 200 : resp[0].to_i
+      code = resp[0].to_i
+      if code != 200
+        @api_errors << "#{code.to_s} on alert #{alert['name']}"
+      end
 
       # client error
       if code == 400
@@ -138,14 +145,15 @@ module Interferon::Destinations
         @stats[:alerts_silenced] += 1 if alert_opts[:silenced]
       end
 
+      id = resp[1].nil? ? nil : resp[1]['id']
       # lets key alerts by their name
-      return alert['name']
+      return [alert['name'], id]
     end
 
     def remove_alert(alert)
       if alert['message'].include?(ALERT_KEY)
         log.debug("deleting alert #{alert['id']} (#{alert['name']})")
-        @dog.delete_alert(alert['id']) unless @dry_run
+        @dog.delete_alert(alert['id'])
         @stats[:alerts_deleted] += 1
       else
         log.warn("not deleting manually-created alert #{alert['id']} (#{alert['name']})")
@@ -162,6 +170,11 @@ module Interferon::Destinations
         @stats[:alerts_updated],
         @stats[:alerts_deleted],
       ]
+    end
+
+    def remove_alert_by_id(alert_id)
+      log.debug("deleting alert, id: #{alert_id}")
+      @dog.delete_alert(alert_id)
     end
   end
 end

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/spec/helpers/dsl_helper.rb
+++ b/spec/helpers/dsl_helper.rb
@@ -1,0 +1,39 @@
+module Interferon
+  module MockDSLMixin
+    def initialize
+    end
+
+    def get_or_set(field, val, block, default)
+      @hash ||= Hash.new
+      if val.nil?
+        return @hash[field]
+      else
+        @hash[field] = val
+      end
+    end
+  end
+
+  class MockAlertDSL < AlertDSL
+    include MockDSLMixin
+
+    def notify(v = nil)
+      get_or_set(:notify, v, nil, nil)
+    end
+
+    def metric(v = nil)
+      get_or_set(:metric, v, nil, nil)
+    end
+
+    def id(v = nil, &block)
+      get_or_set(:@id, v, block, '')
+    end
+  end
+
+  class MockNotifyDSL < NotifyDSL
+    include MockDSLMixin
+  end
+
+  class MockMetricDSL < MetricDSL
+    include MockDSLMixin
+  end
+end

--- a/spec/helpers/mock_alert.rb
+++ b/spec/helpers/mock_alert.rb
@@ -1,0 +1,11 @@
+module Interferon
+  class MockAlert < Alert
+    def initialize(dsl)
+      @dsl = dsl
+    end
+
+    def []=(key, val)
+      @dsl.get_or_set(("@"+ key).to_sym, val, nil, nil)
+    end
+  end
+end

--- a/spec/lib/interferon_spec.rb
+++ b/spec/lib/interferon_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'helpers/mock_alert'
+require 'helpers/dsl_helper'
+require 'interferon/destinations/datadog'
+
+include Interferon
+
+describe Interferon::Interferon do
+  it "would not be dry run if only alert message changed" do
+    alert1 = create_test_alert('name1', 'testquery', 'message1', true, 1000, 'test')
+    alert2 = create_test_alert('name2', 'testquery', 'message2', true, 1000, 'test')
+
+    expect(Interferon::Interferon.same_alerts_for_dry_run_purpose(alert1, alert2)).to be true
+  end
+
+  it "would be dry run if alert datadog query changed" do
+    alert1 = create_test_alert('name1', 'testquery1', 'message1', true, 1000, 'test')
+    alert2 = create_test_alert('name2', 'testquery2', 'message2', true, 1000, 'test')
+
+    expect(Interferon::Interferon.same_alerts_for_dry_run_purpose(alert1, alert2)).to be false
+  end
+
+  context "dry_run_update_alerts_on_destination" do
+    let(:the_existing_alerts) {mock_existing_alerts}
+    let(:dest) {MockDest.new(the_existing_alerts)}
+    before do
+      allow_any_instance_of(MockAlert).to receive(:evaluate)
+      allow(dest).to receive(:remove_alert_by_id)
+      allow(dest).to receive(:report_stats)
+    end
+
+    it 'dry run does not re-run existing alerts' do
+      alerts = mock_existing_alerts
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil)
+      expect(dest).not_to receive(:create_alert)
+      expect(dest).not_to receive(:remove_alert_by_id)
+      
+      interferon.dry_run_update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2']], {})
+    end
+
+    it 'dry run runs added alerts' do
+      alerts = mock_existing_alerts
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil)
+      added = create_test_alert('name3', 'testquery3', '', true, 1000, true)
+      expect(dest).to receive(:create_alert).once.and_call_original
+      expect(dest).to receive(:remove_alert_by_id).with('[-dry-run-]name3').once
+      
+      interferon.dry_run_update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2'], added], {})
+    end
+
+    it 'dry run runs updated alerts' do
+      alerts = mock_existing_alerts
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil)
+      added = create_test_alert('name1', 'testquery3', '', true, 1000, true)
+      expect(dest).to receive(:create_alert).once.and_call_original
+      expect(dest).to receive(:remove_alert_by_id).with('[-dry-run-]name1').once
+      
+      interferon.dry_run_update_alerts_on_destination(dest, ['host'], [alerts['name2'], added], {})
+    end
+
+    def mock_existing_alerts
+      alert1 = create_test_alert('name1', 'testquery1', '', true, 1000, true)
+      alert2 = create_test_alert('name2', 'testquery2', '', true, 1000, true)
+      {'name1'=>alert1, 'name2'=>alert2}
+    end
+
+    class MockDest < Interferon::Destinations::Datadog
+      @existing_alerts
+
+      def initialize(the_existing_alerts)
+        @existing_alerts = the_existing_alerts
+      end
+
+      def create_alert(alert, people)
+        name = alert['name']
+        [name, name]
+      end
+
+      def existing_alerts
+        @existing_alerts
+      end
+    end
+  end
+
+  def create_test_alert(name, datadog_query, message, notify_no_data, no_data_timeframe, applies)
+    alert_dsl = MockAlertDSL.new
+    metric_dsl = MockMetricDSL.new
+    metric_dsl.datadog_query(datadog_query)
+    alert_dsl.metric(metric_dsl)
+    alert_dsl.name(name)
+    alert_dsl.message(message)
+    alert_dsl.notify_no_data(notify_no_data)
+    alert_dsl.no_data_timeframe(no_data_timeframe)
+    alert_dsl.applies(applies)
+    notify_dsl = MockNotifyDSL.new
+    notify_dsl.groups(['a'])
+    alert_dsl.notify(notify_dsl)
+    MockAlert.new(alert_dsl)
+  end
+end

--- a/spec/lib/interferon_spec.rb
+++ b/spec/lib/interferon_spec.rb
@@ -35,7 +35,7 @@ describe Interferon::Interferon do
       expect(dest).not_to receive(:create_alert)
       expect(dest).not_to receive(:remove_alert_by_id)
       
-      interferon.dry_run_update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2']], {})
+      interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2']], {}, true)
     end
 
     it 'dry run runs added alerts' do
@@ -45,7 +45,7 @@ describe Interferon::Interferon do
       expect(dest).to receive(:create_alert).once.and_call_original
       expect(dest).to receive(:remove_alert_by_id).with('[-dry-run-]name3').once
       
-      interferon.dry_run_update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2'], added], {})
+      interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2'], added], {}, true)
     end
 
     it 'dry run runs updated alerts' do
@@ -55,7 +55,7 @@ describe Interferon::Interferon do
       expect(dest).to receive(:create_alert).once.and_call_original
       expect(dest).to receive(:remove_alert_by_id).with('[-dry-run-]name1').once
       
-      interferon.dry_run_update_alerts_on_destination(dest, ['host'], [added], {})
+      interferon.update_alerts_on_destination(dest, ['host'], [added], {}, true)
     end
 
     def mock_existing_alerts


### PR DESCRIPTION
Dry run now will diff the existing alerts in datadog and the alerts from alerts repo. For new/updated alerts, it try to hit datadog api, creating some test alerts, these alerts will be delete afterwards. If there are api errors during the process, an error is thrown thus to fail the dry-run.

Added test cases and tested end to end on a box.

@wyao
@igor47 
@ziliangpeng 