### PR TITLE
[dogapi] Allow configurable api timeout

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,3 +35,4 @@ destinations:
     options:
       app_key: "fillmein"
       api_key: "alsomissing"
+      api_timeout: 15

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -15,7 +15,9 @@ module Interferon::Destinations
         end
       end
 
-      @dog = Dogapi::Client.new(options['api_key'], options['app_key'])
+      api_timeout = options['api_timeout'] || 15
+      @dog = Dogapi::Client.new(options['api_key'], options['app_key'], nil, nil, true, api_timeout)
+
       @existing_alerts = nil
 
       # create datadog alerts 10 at a time
@@ -41,6 +43,8 @@ module Interferon::Destinations
       unless @existing_alerts
         resp = @dog.get_all_alerts()
         alerts = resp[1]['alerts']
+
+        raise 'Failed to retrieve current alerts from datadog' if alerts.nil?
 
         # key alerts by name
         @existing_alerts = Hash[alerts.map{ |a| [a['name'], a] }]

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end


### PR DESCRIPTION
The default dogapi timeout 5s isn't always enough. Increasing it to 15s while making it configurable

15s was a magic number I chose, let me know if it should be more conservatively increased.

@igor47 
cc: @wyao @airbnb/product-infra 