### PR TITLE
allow alerts to be defined in subdirectories

### DIFF
--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -65,10 +65,10 @@ module Interferon
       abort("no such directory #{path} for reading alert files") \
         unless Dir.exists?(path)
 
-      Dir.glob(File.join(path, '*.rb')) do |alert_file|
+      Dir.glob(File.join(path, '**/*.rb')) do |alert_file|
         break if @request_shutdown
         begin
-          alert = Alert.new(alert_file)
+          alert = Alert.new(@alerts_repo_path, alert_file)
         rescue StandardError => e
           log.warn "error reading alert file #{alert_file}: #{e}"
           failed += 1

--- a/lib/interferon/alert.rb
+++ b/lib/interferon/alert.rb
@@ -1,8 +1,8 @@
 module Interferon
   class Alert
-    def initialize(path)
-      @path = path
-      @filename = File.basename(path)
+    def initialize(alerts_repo_path, alert_path)
+      @path = alert_path
+      @filename = self.class.get_name_from_path(alerts_repo_path, alert_path)
 
       @text = File.read(@path)
 
@@ -36,6 +36,13 @@ module Interferon
       end
 
       return @dsl.send(attr)
+    end
+
+    private
+
+    def self.get_name_from_path(alerts_repo_path, alert_path)
+      base_index = File.join(alerts_repo_path, 'alerts').split(File::SEPARATOR).length
+      alert_path.split(File::SEPARATOR)[base_index..-1].join(File::SEPARATOR)
     end
   end
 end

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end

--- a/spec/lib/interferon/alert_spec.rb
+++ b/spec/lib/interferon/alert_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe '.get_name_from_path' do
+  subject { Interferon::Alert }
+  let(:alerts_repo_path) { '/the/path/to' }
+  let(:base_dir_alert) { '/the/path/to/alerts/alert.rb'}
+  let(:sub_dir_alert) { '/the/path/to/alerts/x/y/alert.rb'}
+
+  it 'only returns the filename for alerts directly under the alerts folder' do
+    expect(subject.get_name_from_path(alerts_repo_path, base_dir_alert)).to eq('alert.rb')
+  end
+
+  it 'returns the relative path for alerts in a subdirectory under the alerts folder' do
+    expect(subject.get_name_from_path(alerts_repo_path, sub_dir_alert)).to eq('x/y/alert.rb')
+  end
+end


### PR DESCRIPTION
Sending out for comment @igor47 I was wondering if pull request such as this would be something you'd consider merging into interferon?

With a large number of alerts, the alerts directory can become quite
large and difficult to browse. This commit allows alerts to be defined
from within arbitrarily nested subdirectories undernead the 'alerts/'
folder.

The subdirectory traversal is accomplished by changing the glob from
`*.rb` to `**/*.rb`.

In oder to prevent name collisions from occuring between two alerts in
different folders but the same file name, we modify `Alert` to make its
name instead a relative path from the 'alerts/' folder. (spec added)
