### PR TITLE
Interferon updates to v0.0.19

### DIFF
--- a/interferon.gemspec
+++ b/interferon.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "diffy", "~> 3.1.0", ">= 3.1.0"
   gem.add_runtime_dependency "parallel", "~> 1.9", ">= 1.9.0"
   gem.add_runtime_dependency "nokogiri", "< 1.7.0"
+  gem.add_runtime_dependency "tzinfo", "~> 1.2.2", ">= 1.2.2"
 
   gem.add_development_dependency "rspec", "~> 3.2"
   gem.add_development_dependency "pry", "~> 0.10"

--- a/interferon.gemspec
+++ b/interferon.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "dogstatsd-ruby", "~> 1.4", ">= 1.4.1"
   gem.add_runtime_dependency "diffy", "~> 3.1.0", ">= 3.1.0"
   gem.add_runtime_dependency "parallel", "~> 1.9", ">= 1.9.0"
+  gem.add_runtime_dependency "nokogiri", "< 1.7.0"
 
   gem.add_development_dependency "rspec", "~> 3.2"
   gem.add_development_dependency "pry", "~> 0.10"

--- a/interferon.gemspec
+++ b/interferon.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "aws-sdk", "~> 1.35", ">= 1.35.1"
   gem.add_runtime_dependency "dogstatsd-ruby", "~> 1.4", ">= 1.4.1"
   gem.add_runtime_dependency "diffy", "~> 3.1.0", ">= 3.1.0"
+  gem.add_runtime_dependency "parallel", "~> 1.9", ">= 1.9.0"
 
   gem.add_development_dependency "rspec", "~> 3.2"
   gem.add_development_dependency "pry", "~> 0.10"

--- a/interferon.gemspec
+++ b/interferon.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "dogapi", "~> 1.11", ">= 1.11.1"
   gem.add_runtime_dependency "aws-sdk", "~> 1.35", ">= 1.35.1"
   gem.add_runtime_dependency "dogstatsd-ruby", "~> 1.4", ">= 1.4.1"
+  gem.add_runtime_dependency "diffy", "~> 3.1.0", ">= 3.1.0"
 
   gem.add_development_dependency "rspec", "~> 3.2"
   gem.add_development_dependency "pry", "~> 0.10"

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -147,7 +147,7 @@ module Interferon
       start_time = Time.new.to_f
 
       # get already-defined alerts
-      existing_alerts = dest.existing_alerts.dup
+      existing_alerts = dest.existing_alerts
 
       if dry_run
         do_dry_run_update(dest, hosts, alerts, existing_alerts, groups)
@@ -174,40 +174,75 @@ module Interferon
     end
 
     def do_dry_run_update(dest, hosts, alerts, existing_alerts, groups)
-      to_remove = existing_alerts.reject{|key, a| !key.start_with?(DRY_RUN_ALERTS_NAME_PREFIX)}
-      alerts_queue = build_alerts_queue(hosts, alerts, groups)
-      alerts_queue.reject!{|name, pair| !Interferon::need_dry_run(pair[0], existing_alerts)}
-      alerts_queue.each do |name, pair|
-        alert = pair[0]
-        alert.change_name(DRY_RUN_ALERTS_NAME_PREFIX + alert['name'])
+      # Track these to clean up dry-run alerts from previous runs
+      existing_dry_run_alerts = []
+      existing_alerts.each do |name, alert|
+        if name.start_with?(DRY_RUN_ALERTS_NAME_PREFIX)
+          existing_dry_run_alerts << [alert['name'], alert['id']]
+        end
       end
 
-      # flush queue
-      created_alerts_key_ids = create_alerts(dest, alerts_queue)
-      created_alerts_ids = created_alerts_key_ids.map{|a| a[1]}
-      to_remove_ids = to_remove.empty? ? [] : to_remove.map{|a| a['id']}
-      # remove existing alerts that shouldn't exist
-      (created_alerts_ids + to_remove_ids).each do |id|
-        break if @request_shutdown
-        dest.remove_alert_by_id(id) unless id.nil?
+      # Add dry-run prefix to alerts and delete id to avoid impacting real alerts
+      existing_alerts.keys.each do |name|
+        existing_alert = existing_alerts[name]
+        dry_run_alert_name = DRY_RUN_ALERTS_NAME_PREFIX + name
+        existing_alert['name'] = dry_run_alert_name
+        existing_alert['id'] = nil
+        existing_alerts[dry_run_alert_name] = existing_alerts.delete(name)
       end
+
+      # Build new queue with dry-run prefixes
+      alerts_queue = build_alerts_queue(hosts, alerts, groups)
+      alerts_queue.each do |name, alert_people_pair|
+        alert = alert_people_pair[0]
+        dry_run_alert_name = DRY_RUN_ALERTS_NAME_PREFIX + alert['name']
+        alert.change_name(dry_run_alert_name)
+      end
+
+      updates_queue = alerts_queue.reject{
+        |name, alert_people_pair| !Interferon::need_update(dest, alert_people_pair, existing_alerts)}
+
+      # Existing alerts are pruned until all that remains are alerts that aren't being generated anymore
+      to_remove = existing_alerts.dup
+      alerts_queue.each do |name, alert_people_pair|
+        alert = alert_people_pair[0]
+        to_remove.delete(alert['name'])
+      end
+
+      # Create alerts in destination
+      created_alerts = create_alerts(dest, updates_queue)
+
+      # Clean up dry-run created alerts
+      (created_alerts + existing_dry_run_alerts).each do |alert_id_pair|
+        alert_id = alert_id_pair[1]
+        dest.remove_alert_by_id(alert_id)
+      end
+
+      # Log dry-run creations that are actually updates
+      dry_run_updates = updates_queue.reject{
+        |name, alert_people_pair| existing_alerts[alert_people_pair[0]['name']].nil?}
+      log.info "datadog: [dry-run] #{dry_run_updates.length} alerts pending update: #{dry_run_updates.keys}"
+      # Log clean up of alerts not longer being generated
+      log.info "datadog: [dry-run] #{to_remove.length} alerts pending deletion: #{to_remove.keys}"
     end
 
     def do_regular_update(dest, hosts, alerts, existing_alerts, groups)
-      existing_alerts.each{ |key, existing_alert| existing_alert['still_exists'] = false }
-
       alerts_queue = build_alerts_queue(hosts, alerts, groups)
+      updates_queue = alerts_queue.reject{
+        |name, alert_people_pair| !Interferon::need_update(dest, alert_people_pair, existing_alerts)}
 
-      # flush queue
-      created_alerts_keys = create_alerts(dest, alerts_queue).map{|a| a[0]}
-      created_alerts_keys.each do |alert_key|
-        # don't delete alerts we still have defined
-        existing_alerts[alert_key]['still_exists'] = true if existing_alerts.include?(alert_key)
+      # Create alerts in destination
+      create_alerts(dest, updates_queue)
+
+      # Existing alerts are pruned until all that remains are alerts that aren't being generated anymore
+      to_remove = existing_alerts.dup
+      alerts_queue.each do |name, alert_people_pair|
+        alert = alert_people_pair[0]
+        to_remove.delete(alert['name'])
       end
 
-      # remove existing alerts that shouldn't exist
-      to_delete = existing_alerts.reject{ |key, existing_alert| existing_alert['still_exists'] }
-      to_delete.each do |key, alert|
+      # Clean up alerts not longer being generated
+      to_remove.each do |name, alert|
         break if @request_shutdown
         dest.remove_alert(alert)
       end
@@ -289,7 +324,7 @@ module Interferon
         end
 
         # did the alert fail to evaluate on all hosts?
-        if counters[:errors] == counters[:hosts]
+        if counters[:errors] == counters[:hosts] and !last_eval_error.nil?
           log.error "alert #{alert} failed to evaluate in the context of all hosts!"
           log.error "last error on alert #{alert}: #{last_eval_error}"
 
@@ -310,21 +345,23 @@ module Interferon
       alerts_queue
     end
 
-    def self.need_dry_run(alert, existing_alerts_from_api)
+    def self.need_update(dest, alert_people_pair, existing_alerts_from_api)
+      alert = alert_people_pair[0]
       existing = existing_alerts_from_api[alert['name']]
       if existing.nil?
         true
       else
-        !same_alerts_for_dry_run_purpose(alert, existing)
+        !same_alerts(dest, alert_people_pair, existing)
       end
     end
 
-    def self.same_alerts_for_dry_run_purpose(alert, alert_api_json)
-      query1 = alert['metric']['datadog_query']
-      query2 = alert_api_json['query']
-      query1.strip!
-      query2.strip!
-      query1 == query2
+    def self.same_alerts(dest, alert_people_pair, alert_api_json)
+      alert, people = alert_people_pair
+      query1 = alert['metric']['datadog_query'].strip
+      message1 = dest.generate_message(alert['message'], people).strip
+      query2 = alert_api_json['query'].strip
+      message2 = alert_api_json['message'].strip
+      query1 == query2 and message1 == message2
     end
   end
 end

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -225,7 +225,7 @@ module Interferon
           if old_alerts['id'].length == 1
             to_remove.delete(alert['name'])
           else
-            old_alerts['id'] = old_alerts['id'].drop(0)
+            old_alerts['id'] = old_alerts['id'].drop(1)
           end
         end
       end
@@ -265,7 +265,7 @@ module Interferon
           if alert['id'].length == 1
             to_remove.delete(alert['name'])
           else
-            old_alerts['id'] = old_alerts['id'].drop(0)
+            old_alerts['id'] = old_alerts['id'].drop(1)
           end
         end
       end

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -23,11 +23,12 @@ module Interferon
     # groups_sources is a hash from type => options for each group source
     # host_sources is a hash from type => options for each host source
     # destinations is a similiar hash from type => options for each alerter
-    def initialize(alerts_repo_path, groups_sources, host_sources, destinations)
+    def initialize(alerts_repo_path, groups_sources, host_sources, destinations, dry_run=false)
       @alerts_repo_path = alerts_repo_path
       @groups_sources = groups_sources
       @host_sources = host_sources
       @destinations = destinations
+      @dry_run = dry_run
       @request_shutdown = false
     end
 
@@ -36,7 +37,8 @@ module Interferon
         log.info "SIGTERM received. shutting down gracefully..."
         @request_shutdown = true
       end
-      run_desc = dry_run ? 'dry run' : 'run'
+      @dry_run = dry_run
+      run_desc = @dry_run ? 'dry run' : 'run'
       log.info "beginning alerts #{run_desc}"
 
       alerts = read_alerts
@@ -45,9 +47,12 @@ module Interferon
 
       @destinations.each do |dest|
         dest['options'] ||= {}
+        if @dry_run
+          dest['options']['dry_run'] = true
+        end
       end
 
-      update_alerts(@destinations, hosts, alerts, groups, dry_run)
+      update_alerts(@destinations, hosts, alerts, groups)
 
       if @request_shutdown
         log.info "interferon #{run_desc} shut down by SIGTERM"
@@ -133,23 +138,23 @@ module Interferon
       return hosts
     end
 
-    def update_alerts(destinations, hosts, alerts, groups, dry_run)
+    def update_alerts(destinations, hosts, alerts, groups)
       loader = DestinationsLoader.new([@alerts_repo_path])
       loader.get_all(destinations).each do |dest|
         break if @request_shutdown
         log.info "updating alerts on #{dest.class.name}"
-        update_alerts_on_destination(dest, hosts, alerts, groups, dry_run)
+        update_alerts_on_destination(dest, hosts, alerts, groups)
       end
     end
 
-    def update_alerts_on_destination(dest, hosts, alerts, groups, dry_run)
+    def update_alerts_on_destination(dest, hosts, alerts, groups)
       # track some counters/stats per destination
       start_time = Time.new.to_f
 
       # get already-defined alerts
       existing_alerts = dest.existing_alerts
 
-      if dry_run
+      if @dry_run
         do_dry_run_update(dest, hosts, alerts, existing_alerts, groups)
       else
         do_regular_update(dest, hosts, alerts, existing_alerts, groups)
@@ -159,7 +164,7 @@ module Interferon
         # run time summary
         run_time = Time.new.to_f - start_time
         statsd.histogram(
-          dry_run ? 'destinations.run_time.dry_run' : 'destinations.run_time',
+          @dry_run ? 'destinations.run_time.dry_run' : 'destinations.run_time',
           run_time,
           :tags => ["destination:#{dest.class.name}"])
         log.info "#{dest.class.name} : run completed in %.2f seconds" % (run_time)
@@ -168,7 +173,7 @@ module Interferon
         dest.report_stats
       end
 
-      if dry_run && !dest.api_errors.empty?
+      if @dry_run && !dest.api_errors.empty?
         raise dest.api_errors.to_s
       end
     end
@@ -179,6 +184,7 @@ module Interferon
       existing_alerts.each do |name, alert|
         if name.start_with?(DRY_RUN_ALERTS_NAME_PREFIX)
           existing_dry_run_alerts << [alert['name'], alert['id']]
+          existing_alerts.remove(name)
         end
       end
 
@@ -199,8 +205,12 @@ module Interferon
         alert.change_name(dry_run_alert_name)
       end
 
-      updates_queue = alerts_queue.reject{
-        |name, alert_people_pair| !Interferon::need_update(dest, alert_people_pair, existing_alerts)}
+      updates_queue = alerts_queue.reject do |name, alert_people_pair|
+        !Interferon::need_update(dest, alert_people_pair, existing_alerts)
+      end
+
+      # Create alerts in destination
+      created_alerts = create_alerts(dest, updates_queue)
 
       # Existing alerts are pruned until all that remains are alerts that aren't being generated anymore
       to_remove = existing_alerts.dup
@@ -209,8 +219,11 @@ module Interferon
         to_remove.delete(alert['name'])
       end
 
-      # Create alerts in destination
-      created_alerts = create_alerts(dest, updates_queue)
+      # Clean up alerts not longer being generated
+      to_remove.each do |name, alert|
+        break if @request_shutdown
+        dest.remove_alert(alert)
+      end
 
       # Clean up dry-run created alerts
       (created_alerts + existing_dry_run_alerts).each do |alert_id_pair|
@@ -218,18 +231,13 @@ module Interferon
         dest.remove_alert_by_id(alert_id)
       end
 
-      # Log dry-run creations that are actually updates
-      dry_run_updates = updates_queue.reject{
-        |name, alert_people_pair| existing_alerts[alert_people_pair[0]['name']].nil?}
-      log.info "datadog: [dry-run] #{dry_run_updates.length} alerts pending update: #{dry_run_updates.keys}"
-      # Log clean up of alerts not longer being generated
-      log.info "datadog: [dry-run] #{to_remove.length} alerts pending deletion: #{to_remove.keys}"
     end
 
     def do_regular_update(dest, hosts, alerts, existing_alerts, groups)
       alerts_queue = build_alerts_queue(hosts, alerts, groups)
-      updates_queue = alerts_queue.reject{
-        |name, alert_people_pair| !Interferon::need_update(dest, alert_people_pair, existing_alerts)}
+      updates_queue = alerts_queue.reject do |name, alert_people_pair|
+        !Interferon::need_update(dest, alert_people_pair, existing_alerts)
+      end
 
       # Create alerts in destination
       create_alerts(dest, updates_queue)
@@ -357,11 +365,27 @@ module Interferon
 
     def self.same_alerts(dest, alert_people_pair, alert_api_json)
       alert, people = alert_people_pair
-      query1 = alert['metric']['datadog_query'].strip
-      message1 = dest.generate_message(alert['message'], people).strip
-      query2 = alert_api_json['query'].strip
-      message2 = alert_api_json['message'].strip
-      query1 == query2 and message1 == message2
+
+      prev_alert = {
+        :query => alert_api_json['query'].strip,
+        :message => alert_api_json['message'].strip,
+        :notify_no_data => alert_api_json['notify_no_data'],
+        :silenced => alert_api_json['silenced'],
+        :timeout => alert_api_json['timeout_h'],
+        :no_data_timeframe => alert_api_json['no_data_timeframe']
+      }
+
+      new_alert = {
+        :query => alert['metric']['datadog_query'].strip,
+        :message => dest.generate_message(alert['message'], people).strip,
+        :notify_no_data => alert['notify_no_data'],
+        :silenced => alert['silenced'] || alert['silenced_until'] > Time.now,
+        :timeout => alert['timeout'] || nil,
+        :no_data_timeframe => alert['no_data_timeframe'] || nil
+      }
+
+      prev_alert == new_alert
     end
+
   end
 end

--- a/lib/interferon/alert.rb
+++ b/lib/interferon/alert.rb
@@ -30,6 +30,14 @@ module Interferon
       @dsl.name(name)
     end
 
+    def silence
+      unless @dsl
+        raise "This alert has not yet been evaluated"
+      end
+
+      @dsl.silenced(true)
+    end
+
     def [](attr)
       unless @dsl
         raise "This alert has not yet been evaluated"

--- a/lib/interferon/alert_dsl.rb
+++ b/lib/interferon/alert_dsl.rb
@@ -1,3 +1,4 @@
+require 'interferon/work_hours_helper'
 
 module Interferon
   module DSLMixin
@@ -45,6 +46,15 @@ module Interferon
 
     def silenced_until(v = nil, &block)
       get_or_set(:@silenced_until, v && Time.parse(v), block, Time.at(0))
+    end
+
+    def is_work_hour?(args = {})
+      # Args can contain
+      # :hours => range of work hours (0 to 23h), for example (9..16)
+      # :days => range of week days (0 = sunday), for example (1..5) (Monday to Friday)
+      # :timezone => example 'America/Los_Angeles'
+      # 9 to 5 Monday to Friday in PST is the default
+      WorkHoursHelper.is_work_hour?(Time.now.utc, args)
     end
 
     def notify_no_data(v = nil, &block)

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -107,10 +107,14 @@ module Interferon::Destinations
       alert_opts = {
         :name => alert['name'],
         :message => message,
-        :silenced => alert['silenced'] || alert['silenced_until'] > Time.now,
         :notify_no_data => alert['notify_no_data'],
         :timeout_h => nil,
       }
+
+      # Set alert to be silenced if there is a silenced set or silenced_until set
+      if alert['silenced'] or alert['silenced_until'] > Time.now
+        alert_opts[:silenced] = {"*" => nil}
+      end
 
       # allow an optional timeframe for "no data" alerts to be specified
       # (this feature is supported, even though it's not documented)

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -38,8 +38,11 @@ module Interferon::Destinations
 
       @stats = {
         :alerts_created => 0,
+        :alerts_to_be_created => 0,
         :alerts_updated => 0,
+        :alerts_to_be_updated => 0,
         :alerts_deleted => 0,
+        :alerts_to_be_deleted => 0,
         :alerts_silenced => 0,
         :api_successes => 0,
         :api_client_errors => 0,
@@ -50,6 +53,10 @@ module Interferon::Destinations
 
     def api_errors
       @api_errors ||= []
+    end
+
+    def generate_message(message, people)
+      [message, ALERT_KEY, people.map{ |p| "@#{p}" }].flatten.join("\n")
     end
 
     def existing_alerts
@@ -81,11 +88,7 @@ module Interferon::Destinations
 
     def create_alert(alert, people)
       # create a message which includes the notifications
-      message = [
-        alert['message'],
-        ALERT_KEY,
-        people.map{ |p| "@#{p}" }
-      ].flatten.join("\n")
+      message = generate_message(alert['message'], people)
 
       # create the hash of options to send to datadog
       alert_opts = {
@@ -103,10 +106,13 @@ module Interferon::Destinations
       # timeout is in seconds, but set it to 1 hour at least
       alert_opts[:timeout_h] = [1, (alert['timeout'].to_i / 3600)].max if alert['timeout']
 
+      datadog_query = alert['metric']['datadog_query'].strip
+      existing_alert = existing_alerts[alert['name']]
       # new alert, create it
-      if existing_alerts[alert['name']].nil?
+      if existing_alert.nil? or existing_alert['id'].nil?
         action = :creating
-        log.debug("new alert #{alert['name']}")
+        @stats[:alerts_to_be_created] += 1
+        log.info("creating new alert #{alert['name']}: #{datadog_query} #{message}")
 
         resp = @dog.alert(
           alert['metric']['datadog_query'].strip,
@@ -116,8 +122,16 @@ module Interferon::Destinations
       # existing alert, modify it
       else
         action = :updating
-        id = existing_alerts[alert['name']]['id']
-        log.debug("updating existing alert #{id} (#{alert['name']})")
+        @stats[:alerts_to_be_updated] += 1
+        id = existing_alert['id']
+
+        if datadog_query != existing_alert['query'] and message != existing_alert['message']
+          log.info("updating existing alert #{id} (#{alert['name']}) with new message and query: #{datadog_query} #{message}")
+        elsif message != existing_alert['message']
+          log.info("updating existing alert #{id} (#{alert['name']}) with new message: #{message}")
+        else
+          log.info("updating existing alert #{id} (#{alert['name']}) with query: #{datadog_query}")
+        end
 
         resp = @dog.update_alert(
           id,
@@ -128,39 +142,11 @@ module Interferon::Destinations
 
       # log whenever we've encountered errors
       code = resp[0].to_i
-      if code != 200
-        api_errors << "#{code.to_s} on alert #{alert['name']}"
-      end
-
-      # client error
-      if code == 400
-        statsd.gauge('datadog.api.unknown_error', 0, :tags => ["alert:#{alert}"])
-        statsd.gauge('datadog.api.client_error', 1, :tags => ["alert:#{alert}"])
-        statsd.gauge('datadog.api.success', 0, :tags => ["alert:#{alert}"])
-
-        @stats[:api_client_errors] += 1
-        log.error("client error while #{action} alert '#{alert['name']}';" \
-            " query was '#{alert['metric']['datadog_query'].strip}'" \
-            " response was #{resp[0]}:'#{resp[1].inspect}'")
-
-      # unknown (prob. datadog) error:
-      elsif code >= 400 || code == -1
-        statsd.gauge('datadog.api.unknown_error', 1, :tags => ["alert:#{alert}"])
-        statsd.gauge('datadog.api.client_error', 0, :tags => ["alert:#{alert}"])
-        statsd.gauge('datadog.api.success', 0, :tags => ["alert:#{alert}"])
-
-        @stats[:api_unknown_errors] += 1
-        log.error("unknown error while #{action} alert '#{alert['name']}':" \
-            " query was '#{alert['metric']['datadog_query'].strip}'" \
-            " response was #{resp[0]}:'#{resp[1].inspect}'")
+      log_datadog_response_code(resp, code, action, alert)
 
       # assume this was a success
-      else
-        statsd.gauge('datadog.api.unknown_error', 0, :tags => ["alert:#{alert}"])
-        statsd.gauge('datadog.api.client_error', 0, :tags => ["alert:#{alert}"])
-        statsd.gauge('datadog.api.success', 1, :tags => ["alert:#{alert}"])
-
-        @stats[:api_successes] += 1
+      if !(code >= 400 || code == -1)
+        # assume this was a success
         @stats[:alerts_created] += 1 if action == :creating
         @stats[:alerts_updated] += 1 if action == :updating
         @stats[:alerts_silenced] += 1 if alert_opts[:silenced]
@@ -173,9 +159,7 @@ module Interferon::Destinations
 
     def remove_alert(alert)
       if alert['message'].include?(ALERT_KEY)
-        log.debug("deleting alert #{alert['id']} (#{alert['name']})")
-        @dog.delete_alert(alert['id'])
-        @stats[:alerts_deleted] += 1
+        remove_alert_by_id(alert['id'])
       else
         log.warn("not deleting manually-created alert #{alert['id']} (#{alert['name']})")
       end
@@ -186,17 +170,68 @@ module Interferon::Destinations
         statsd.gauge("datadog.#{k}", v)
       end
 
-      log.info "datadog: created %d updated %d and deleted %d alerts" % [
+      log.info "datadog: successfully created (%d/%d), updated (%d/%d), and deleted (%d/%d) alerts" % [
         @stats[:alerts_created],
+        @stats[:alerts_to_be_created],
         @stats[:alerts_updated],
+        @stats[:alerts_to_be_updated],
         @stats[:alerts_deleted],
+        @stats[:alerts_to_be_deleted],
       ]
     end
 
     def remove_alert_by_id(alert_id)
       log.debug("deleting alert, id: #{alert_id}")
-      @dog.delete_alert(alert_id)
-      @stats[:alerts_deleted] += 1
+      @stats[:alerts_to_be_deleted] += 1
+
+      resp = @dog.delete_alert(alert_id)
+      code = resp[0].to_i
+      log_datadog_response_code(resp, code, :deleting)
+
+      if !(code >= 300 || code == -1)
+        # assume this was a success
+        @stats[:alerts_deleted] += 1
+      end
     end
+
+    def log_datadog_response_code(resp, code, action, alert=nil)
+      # log whenever we've encountered errors
+      if code != 200 and !alert.nil?
+        api_errors << "#{code.to_s} on alert #{alert['name']}"
+      end
+
+      # client error
+      if code == 400
+        @stats[:api_client_errors] += 1
+        if !alert.nil?
+          statsd.gauge('datadog.api.unknown_error', 0, :tags => ["alert:#{alert}"])
+          statsd.gauge('datadog.api.client_error', 1, :tags => ["alert:#{alert}"])
+          statsd.gauge('datadog.api.success', 0, :tags => ["alert:#{alert}"])
+          log.error("client error while #{action} alert '#{alert['name']}';" \
+                    " query was '#{alert['metric']['datadog_query'].strip}'" \
+                    " response was #{resp[0]}:'#{resp[1].inspect}'")
+        end
+
+        # unknown (prob. datadog) error:
+      elsif code > 400 || code == -1
+        @stats[:api_unknown_errors] += 1
+        if !alert.nil?
+          statsd.gauge('datadog.api.unknown_error', 1, :tags => ["alert:#{alert}"])
+          statsd.gauge('datadog.api.client_error', 0, :tags => ["alert:#{alert}"])
+          statsd.gauge('datadog.api.success', 0, :tags => ["alert:#{alert}"])
+          log.error("unknown error while #{action} alert '#{alert['name']}':" \
+                    " query was '#{alert['metric']['datadog_query'].strip}'" \
+                    " response was #{resp[0]}:'#{resp[1].inspect}'")
+        end
+      else
+        @stats[:api_successes] += 1
+        if !alert.nil?
+          statsd.gauge('datadog.api.unknown_error', 0, :tags => ["alert:#{alert}"])
+          statsd.gauge('datadog.api.client_error', 0, :tags => ["alert:#{alert}"])
+          statsd.gauge('datadog.api.success', 1, :tags => ["alert:#{alert}"])
+        end
+      end
+    end
+
   end
 end

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -1,5 +1,8 @@
+require 'diffy'
 require 'dogapi'
 require 'set'
+
+Diffy::Diff.default_format = :text
 
 module Interferon::Destinations
   class Datadog
@@ -32,6 +35,7 @@ module Interferon::Destinations
       @dog = Dogapi::Client.new(*args)
 
       @existing_alerts = nil
+      @dry_run = options['dry_run']
 
       # create datadog alerts 10 at a time
       @concurrency = 10
@@ -108,11 +112,13 @@ module Interferon::Destinations
 
       datadog_query = alert['metric']['datadog_query'].strip
       existing_alert = existing_alerts[alert['name']]
+
       # new alert, create it
-      if existing_alert.nil? or existing_alert['id'].nil?
+      if existing_alert.nil?
         action = :creating
         @stats[:alerts_to_be_created] += 1
-        log.info("creating new alert #{alert['name']}: #{datadog_query} #{message}")
+        new_alert_text = "Query: #{datadog_query} Message: #{message.split().join(' ')}"
+        log.info("creating new alert #{alert['name']}: #{new_alert_text}")
 
         resp = @dog.alert(
           alert['metric']['datadog_query'].strip,
@@ -125,19 +131,23 @@ module Interferon::Destinations
         @stats[:alerts_to_be_updated] += 1
         id = existing_alert['id']
 
-        if datadog_query != existing_alert['query'] and message != existing_alert['message']
-          log.info("updating existing alert #{id} (#{alert['name']}) with new message and query: #{datadog_query} #{message}")
-        elsif message != existing_alert['message']
-          log.info("updating existing alert #{id} (#{alert['name']}) with new message: #{message}")
-        else
-          log.info("updating existing alert #{id} (#{alert['name']}) with query: #{datadog_query}")
-        end
+        new_alert_text = "Query:\n#{datadog_query}\nMessage:\n#{message}"
+        existing_alert_text = "Query:\n#{existing_alert['query']}\nMessage:\n#{existing_alert['message']}\n"
+        diff = Diffy::Diff.new(existing_alert_text, new_alert_text, :context=>1)
+        log.info("updating existing alert #{id} (#{alert['name']}): #{diff}")
 
-        resp = @dog.update_alert(
-          id,
-          alert['metric']['datadog_query'].strip,
-          alert_opts
-        )
+        if @dry_run
+          resp = @dog.alert(
+            alert['metric']['datadog_query'].strip,
+            alert_opts,
+          )
+        else
+          resp = @dog.update_alert(
+            id,
+            alert['metric']['datadog_query'].strip,
+            alert_opts
+          )
+        end
       end
 
       # log whenever we've encountered errors
@@ -159,7 +169,19 @@ module Interferon::Destinations
 
     def remove_alert(alert)
       if alert['message'].include?(ALERT_KEY)
-        remove_alert_by_id(alert['id'])
+        @stats[:alerts_to_be_deleted] += 1
+        log.info("deleting alert: #{alert['name']}")
+
+        if not @dry_run
+          resp = @dog.delete_alert(alert['id'])
+          code = resp[0].to_i
+          log_datadog_response_code(resp, code, :deleting)
+
+          if !(code >= 300 || code == -1)
+            # assume this was a success
+            @stats[:alerts_deleted] += 1
+          end
+        end
       else
         log.warn("not deleting manually-created alert #{alert['id']} (#{alert['name']})")
       end
@@ -181,17 +203,11 @@ module Interferon::Destinations
     end
 
     def remove_alert_by_id(alert_id)
+      # This should only be used by dry-run to clean up created dry-run alerts
       log.debug("deleting alert, id: #{alert_id}")
-      @stats[:alerts_to_be_deleted] += 1
-
       resp = @dog.delete_alert(alert_id)
       code = resp[0].to_i
       log_datadog_response_code(resp, code, :deleting)
-
-      if !(code >= 300 || code == -1)
-        # assume this was a success
-        @stats[:alerts_deleted] += 1
-      end
     end
 
     def log_datadog_response_code(resp, code, action, alert=nil)

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -75,7 +75,16 @@ module Interferon::Destinations
         alerts = resp[1]['alerts']
 
         # key alerts by name
-        @existing_alerts = Hash[alerts.map{ |a| [a['name'], a] }]
+        @existing_alerts = {}
+        alerts.each do |alert|
+          existing_alert = @existing_alerts[alert['name']]
+          if existing_alert.nil?
+            alert['id'] = [alert['id']]
+            @existing_alerts[alert['name']] = alert
+          else
+            existing_alert['id'] << alert['id']
+          end
+        end
 
         # count how many are manually created
         @stats[:manually_created_alerts] = \
@@ -129,7 +138,7 @@ module Interferon::Destinations
       else
         action = :updating
         @stats[:alerts_to_be_updated] += 1
-        id = existing_alert['id']
+        id = existing_alert['id'][0]
 
         new_alert_text = "Query:\n#{datadog_query}\nMessage:\n#{message}"
         existing_alert_text = "Query:\n#{existing_alert['query']}\nMessage:\n#{existing_alert['message']}\n"
@@ -162,7 +171,7 @@ module Interferon::Destinations
         @stats[:alerts_silenced] += 1 if alert_opts[:silenced]
       end
 
-      id = resp[1].nil? ? nil : resp[1]['id']
+      id = resp[1].nil? ? nil : [resp[1]['id']]
       # lets key alerts by their name
       return [alert['name'], id]
     end
@@ -173,13 +182,15 @@ module Interferon::Destinations
         log.info("deleting alert: #{alert['name']}")
 
         if not @dry_run
-          resp = @dog.delete_alert(alert['id'])
-          code = resp[0].to_i
-          log_datadog_response_code(resp, code, :deleting)
+          alert['id'].each do |alert_id|
+            resp = @dog.delete_alert(alert_id)
+            code = resp[0].to_i
+            log_datadog_response_code(resp, code, :deleting)
 
-          if !(code >= 300 || code == -1)
-            # assume this was a success
-            @stats[:alerts_deleted] += 1
+            if !(code >= 300 || code == -1)
+              # assume this was a success
+              @stats[:alerts_deleted] += 1
+            end
           end
         end
       else

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -107,13 +107,14 @@ module Interferon::Destinations
       alert_opts = {
         :name => alert['name'],
         :message => message,
+        :silenced => false,
         :notify_no_data => alert['notify_no_data'],
         :timeout_h => nil,
       }
 
       # Set alert to be silenced if there is a silenced set or silenced_until set
-      if alert['silenced'] or alert['silenced_until'] > Time.now
-        alert_opts[:silenced] = {"*" => nil}
+      if alert['silenced'] || alert['silenced_until'] > Time.now
+        alert_opts[:silenced] = true
       end
 
       # allow an optional timeframe for "no data" alerts to be specified
@@ -160,6 +161,11 @@ module Interferon::Destinations
             alert['metric']['datadog_query'].strip,
             alert_opts
           )
+          # Unmute existing alerts that have been unsilenced.
+          # Datadog does not allow updates to silencing via the update_alert API call.
+          if existing_alert['silenced'] && !alert_opts[:silenced]
+            @dog.unmute_monitor(id)
+          end
         end
       end
 
@@ -185,7 +191,7 @@ module Interferon::Destinations
         @stats[:alerts_to_be_deleted] += 1
         log.info("deleting alert: #{alert['name']}")
 
-        if not @dry_run
+        if !@dry_run
           alert['id'].each do |alert_id|
             resp = @dog.delete_alert(alert_id)
             code = resp[0].to_i
@@ -227,7 +233,7 @@ module Interferon::Destinations
 
     def log_datadog_response_code(resp, code, action, alert=nil)
       # log whenever we've encountered errors
-      if code != 200 and !alert.nil?
+      if code != 200 && !alert.nil?
         api_errors << "#{code.to_s} on alert #{alert['name']}"
       end
 

--- a/lib/interferon/group_sources/filesystem.rb
+++ b/lib/interferon/group_sources/filesystem.rb
@@ -11,6 +11,7 @@ module Interferon::GroupSources
 
     def list_groups
       groups = {}
+      aliases = {}
 
       @paths.each do |path|
         path = File.expand_path(path)
@@ -19,7 +20,7 @@ module Interferon::GroupSources
           next
         end
 
-        Dir.glob(File.join(path, '*.{json,yml,yaml}')) do |group_file|
+        Dir.glob(File.join(path, '*.{json,yml,yaml}')).each do |group_file|
           begin
             group = YAML::parse(File.read(group_file))
           rescue YAML::SyntaxError => e
@@ -28,8 +29,22 @@ module Interferon::GroupSources
             log.warn "error reading group file #{group_file}: #{e}"
           else
             group = group.to_ruby
-            groups[group['name']] = group['people'] || []
+            if group['people']
+              groups[group['name']] = group['people'] || []
+            elsif group['alias_for']
+              aliases[group['name']] = {:group => group['alias_for'], :group_file => group_file}
+            end
           end
+        end
+      end
+
+      aliases.each do |aliased_group, group_info|
+        group = group_info[:group]
+        group_file = group_info[:group_file]
+        if groups.include?(group)
+          groups[aliased_group] = groups[group]
+        else
+          log.warn "Alias not found for #{group} but used by #{aliased_group} in #{group_file}"
         end
       end
 

--- a/lib/interferon/group_sources/filesystem.rb
+++ b/lib/interferon/group_sources/filesystem.rb
@@ -1,3 +1,4 @@
+include ::Interferon::Logging
 
 module Interferon::GroupSources
   class Filesystem

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.13"
+  VERSION = "0.0.14"
 end

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.14"
+  VERSION = "0.0.16"
 end

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 end

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.18"
+  VERSION = "0.0.19"
 end

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = "0.0.16"
+  VERSION = "0.0.18"
 end

--- a/lib/interferon/work_hours_helper.rb
+++ b/lib/interferon/work_hours_helper.rb
@@ -1,0 +1,21 @@
+require 'tzinfo'
+
+module Interferon
+  class WorkHoursHelper
+    DEFAULT_WORK_DAYS = (1..5)
+    DEFAULT_WORK_HOURS = (9..16)
+    DEFAULT_WORK_TIMEZONE = 'America/Los_Angeles'
+    DEFAULT_WORK_ARGS = {
+      :hours => DEFAULT_WORK_HOURS,
+      :days => DEFAULT_WORK_DAYS,
+      :timezone => DEFAULT_WORK_TIMEZONE,
+    }.freeze
+
+    def self.is_work_hour?(time, args = {})
+      args = args.merge(DEFAULT_WORK_ARGS)
+      tz = TZInfo::Timezone.get args[:timezone]
+      time_in_tz = time + tz.period_for_utc(time).utc_offset
+      return args[:days].include?(time_in_tz.wday) && args[:hours].include?(time_in_tz.hour)
+    end
+  end
+end

--- a/spec/helpers/dsl_helper.rb
+++ b/spec/helpers/dsl_helper.rb
@@ -6,7 +6,8 @@ module Interferon
     def get_or_set(field, val, block, default)
       @hash ||= Hash.new
       if val.nil?
-        return @hash[field]
+        f = @hash[field]
+        f.nil? ? default : f
       else
         @hash[field] = val
       end
@@ -26,6 +27,14 @@ module Interferon
 
     def id(v = nil, &block)
       get_or_set(:@id, v, block, '')
+    end
+
+    def silenced(v = nil, &block)
+      get_or_set(:@silenced, v, block, false)
+    end
+
+    def silenced_until(v = nil, &block)
+      get_or_set(:@silenced_until, v && Time.parse(v), block, Time.at(0))
     end
   end
 

--- a/spec/helpers/mock_alert.rb
+++ b/spec/helpers/mock_alert.rb
@@ -1,6 +1,7 @@
 module Interferon
   class MockAlert < Alert
     def initialize(dsl)
+      @filename = 'MOCKALERT'
       @dsl = dsl
     end
 

--- a/spec/lib/interferon/group_sources/filesystem_spec.rb
+++ b/spec/lib/interferon/group_sources/filesystem_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'interferon/group_sources/filesystem'
+
+describe Interferon::GroupSources::Filesystem do
+  let (:fs_loader) { Interferon::GroupSources::Filesystem.new({'paths' => ['/tmp']}) }
+
+  describe 'list_groups' do
+    context "with basic groups" do
+      before do
+        group_a = double()
+        expect(File).to receive(:read).with('group_a.yaml').and_return('group_a_text')
+        expect(Psych).to receive(:parse).and_return(group_a)
+        expect(group_a).to receive(:to_ruby).and_return({'name' => 'group_a',
+                                                         'people' => ['Alice', 'Bob']})
+
+        group_b = double()
+        expect(File).to receive(:read).with('group_b.yaml').and_return('group_b_text')
+        expect(Psych).to receive(:parse).and_return(group_b)
+        expect(group_b).to receive(:to_ruby).and_return({'name' => 'group_b',
+                                                         'people' => ['Carol', 'Dave']})
+      end
+
+      it 'loads groups defined by YAML' do
+        expect(Dir).to receive(:glob).and_return(['group_a.yaml', 'group_b.yaml'].each)
+
+        groups = fs_loader.list_groups()
+        expect(groups).to eq({'group_a' => ['Alice', 'Bob'], 'group_b' => ['Carol', 'Dave']})
+      end
+
+      it 'allows groups to be aliased in YAML' do
+        expect(Dir).to receive(:glob).and_return(['group_a.yaml', 'group_b.yaml', 'group_c.yaml'].each)
+        group_c = double()
+        expect(File).to receive(:read).with('group_c.yaml').and_return('group_c_text')
+        expect(Psych).to receive(:parse).and_return(group_c)
+        expect(group_c).to receive(:to_ruby).and_return({'name' => 'group_c', 'alias_for' => 'group_b'})
+
+        groups = fs_loader.list_groups()
+        expect(groups).to eq({'group_a' => ['Alice', 'Bob'],
+                              'group_b' => ['Carol', 'Dave'],
+                              'group_c' => ['Carol', 'Dave']})
+      end
+
+      it 'skips bad aliases in YAML' do
+        expect(Dir).to receive(:glob).and_return(['group_a.yaml', 'group_b.yaml', 'group_c.yaml'].each)
+        group_c = double()
+        expect(File).to receive(:read).with('group_c.yaml').and_return('group_c_text')
+        expect(Psych).to receive(:parse).and_return(group_c)
+        expect(group_c).to receive(:to_ruby).and_return({'name' => 'group_c', 'alias_for' => 'group_d'})
+
+        groups = fs_loader.list_groups()
+        expect(groups).to eq({'group_a' => ['Alice', 'Bob'],
+                              'group_b' => ['Carol', 'Dave']})
+      end
+    end
+  end
+
+end

--- a/spec/lib/interferon_spec.rb
+++ b/spec/lib/interferon_spec.rb
@@ -53,7 +53,7 @@ describe Interferon::Interferon do
 
     it 'dry run does not re-run existing alerts' do
       alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true)
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true,0)
       expect(dest).not_to receive(:create_alert)
       expect(dest).not_to receive(:remove_alert_by_id)
 
@@ -62,20 +62,20 @@ describe Interferon::Interferon do
 
     it 'dry run runs added alerts' do
       alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true)
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true,0)
       added = create_test_alert('name3', 'testquery3', '')
       expect(dest).to receive(:create_alert).once.and_call_original
-      expect(dest).to receive(:remove_alert_by_id).with('[-dry-run-]name3').once
+      expect(dest).to receive(:remove_alert_by_id).with('3').once
 
       interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2'], added], {})
     end
 
     it 'dry run runs updated alerts' do
       alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true)
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true,0)
       added = create_test_alert('name1', 'testquery3', '')
       expect(dest).to receive(:create_alert).once.and_call_original
-      expect(dest).to receive(:remove_alert_by_id).with('[-dry-run-]name1').once
+      expect(dest).to receive(:remove_alert_by_id).with('1').once
 
       interferon.update_alerts_on_destination(dest, ['host'], [added], {})
     end
@@ -95,7 +95,8 @@ describe Interferon::Interferon do
 
       def create_alert(alert, people)
         name = alert['name']
-        [name, name]
+        id = [alert['name'][-1]]
+        [name, id]
       end
 
       def existing_alerts

--- a/spec/lib/interferon_spec.rb
+++ b/spec/lib/interferon_spec.rb
@@ -7,62 +7,66 @@ include Interferon
 
 describe Interferon::Interferon do
 
-  context "dry_run_update_alerts_on_destination" do
-    let(:the_existing_alerts) {mock_existing_alerts}
-    let(:dest) {MockDest.new(the_existing_alerts)}
-    before do
-      allow_any_instance_of(MockAlert).to receive(:evaluate)
-      allow(dest).to receive(:remove_alert_by_id)
-      allow(dest).to receive(:report_stats)
-    end
+  let(:the_existing_alerts) {mock_existing_alerts}
+  let(:dest) {MockDest.new(the_existing_alerts)}
 
-    it "would be dry run if only alert message changed" do
+  context "when checking alerts have changed" do
+    it "detects a change if alert message is different" do
       alert1 = create_test_alert('name1', 'testquery', 'message1')
       alert2 = mock_alert_json('name2', 'testquery', 'message2')
 
       expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be false
     end
 
-    it "would be dry run if alert datadog query changed" do
+    it "detects a change if datadog query is different" do
       alert1 = create_test_alert('name1', 'testquery1', 'message1')
       alert2 = mock_alert_json('name2', 'testquery2', 'message2')
 
       expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be false
     end
 
-    it "would be not dry run if alert datadog query and message are the same" do
-      alert1 = create_test_alert('name1', 'testquery1', 'message1')
-      alert2 = mock_alert_json('name1', 'testquery1', "message1\nThis alert was created via the alerts framework")
+    it "detects a change if alert notify_no_data is different" do
+      alert1 = create_test_alert('name1', 'testquery1', 'message1', false)
+      alert2 = mock_alert_json('name2', 'testquery2', 'message2', true)
 
-      expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be true
+      expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be false
     end
 
-    it "would be dry run if alert silenced changed" do
+    it "detects a change if alert silenced is different" do
       alert1 = create_test_alert('name1', 'testquery1', 'message1', false, true)
       alert2 = mock_alert_json('name2', 'testquery2', 'message2', false, false)
 
       expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be false
     end
 
-    it "would be dry run if alert notify_no_data changed" do
-      alert1 = create_test_alert('name1', 'testquery1', 'message1', false, false)
-      alert2 = mock_alert_json('name2', 'testquery2', 'message2', true, false)
+    it "does not detect a change when alert datadog query and message are the same" do
+      alert1 = create_test_alert('name1', 'testquery1', 'message1')
+      alert2 = mock_alert_json('name1', 'testquery1', "message1\nThis alert was created via the alerts framework")
 
-      expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be false
+      expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be true
+    end
+  end
+
+  context "dry_run_update_alerts_on_destination" do
+    let(:interferon) {Interferon::Interferon.new(nil,nil,nil,nil,true,0)}
+
+    before do
+      allow_any_instance_of(MockAlert).to receive(:evaluate)
+      allow(dest).to receive(:remove_alert)
+      allow(dest).to receive(:remove_alert_by_id)
+      allow(dest).to receive(:report_stats)
     end
 
-    it 'dry run does not re-run existing alerts' do
+    it 'does not re-run existing alerts' do
       alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true,0)
       expect(dest).not_to receive(:create_alert)
       expect(dest).not_to receive(:remove_alert_by_id)
 
       interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2']], {})
     end
 
-    it 'dry run runs added alerts' do
+    it 'runs added alerts' do
       alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true,0)
       added = create_test_alert('name3', 'testquery3', '')
       expect(dest).to receive(:create_alert).once.and_call_original
       expect(dest).to receive(:remove_alert_by_id).with('3').once
@@ -70,9 +74,7 @@ describe Interferon::Interferon do
       interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2'], added], {})
     end
 
-    it 'dry run runs updated alerts' do
-      alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true,0)
+    it 'runs updated alerts' do
       added = create_test_alert('name1', 'testquery3', '')
       expect(dest).to receive(:create_alert).once.and_call_original
       expect(dest).to receive(:remove_alert_by_id).with('1').once
@@ -80,37 +82,152 @@ describe Interferon::Interferon do
       interferon.update_alerts_on_destination(dest, ['host'], [added], {})
     end
 
-    def mock_existing_alerts
-      alert1 = mock_alert_json('name1', 'testquery1', '')
-      alert2 = mock_alert_json('name2', 'testquery2', '')
-      {'name1'=>alert1, 'name2'=>alert2}
+    it 'deletes old alerts' do
+      expect(dest).to receive(:remove_alert).twice
+
+      interferon.update_alerts_on_destination(dest, ['host'], [], {})
     end
 
-    class MockDest < Interferon::Destinations::Datadog
-      @existing_alerts
+    it 'deletes duplicate old alerts' do
+      alert1 = mock_alert_json('name1', 'testquery1', '', false, false, [1, 2, 3])
+      alert2 = mock_alert_json('name2', 'testquery2', '')
+      existing_alerts = {'name1' => alert1, 'name2' => alert2}
+      dest = MockDest.new(existing_alerts)
+      allow(dest).to receive(:remove_alert)
+      allow(dest).to receive(:remove_alert_by_id)
+      allow(dest).to receive(:report_stats)
 
-      def initialize(the_existing_alerts)
-        @existing_alerts = the_existing_alerts
-      end
+      expect(dest).to receive(:remove_alert).with(existing_alerts['name1'])
+      expect(dest).to receive(:remove_alert).with(existing_alerts['name2'])
 
-      def create_alert(alert, people)
-        name = alert['name']
-        id = [alert['name'][-1]]
-        [name, id]
-      end
+      interferon.update_alerts_on_destination(dest, ['host'], [], {})
+    end
 
-      def existing_alerts
-        @existing_alerts
-      end
+    it 'deletes duplicate old alerts when creating new alert' do
+      alert1 = mock_alert_json('name1', 'testquery1', '', false, false, [1, 2, 3])
+      alert2 = mock_alert_json('name2', 'testquery2', '')
+      existing_alerts = {'name1' => alert1, 'name2' => alert2}
+      dest = MockDest.new(existing_alerts)
+      allow(dest).to receive(:remove_alert)
+      allow(dest).to receive(:remove_alert_by_id)
+      allow(dest).to receive(:report_stats)
+
+      added = create_test_alert('name1', 'testquery1', '')
+
+      # Since we change id to nil we will not be attempting to delete duplicate alerts
+      # during dry run
+      # expect(dest).to receive(:remove_alert).with(existing_alerts['name1'])
+      expect(dest).to receive(:remove_alert).with(existing_alerts['name2'])
+
+      interferon.update_alerts_on_destination(dest, ['host'], [added], {})
     end
   end
 
-  def mock_alert_json(name, datadog_query, message, notify_no_data=false, silenced=false)
+  context "update_alerts_on_destination" do
+    let(:interferon) {Interferon::Interferon.new(nil,nil,nil,nil,false,0)}
+
+    before do
+      allow_any_instance_of(MockAlert).to receive(:evaluate)
+      allow(dest).to receive(:remove_alert)
+      allow(dest).to receive(:remove_alert_by_id)
+      allow(dest).to receive(:report_stats)
+    end
+
+    it 'does not re-run existing alerts' do
+      alerts = mock_existing_alerts
+      expect(dest).not_to receive(:create_alert)
+      expect(dest).not_to receive(:remove_alert_by_id)
+
+      interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2']], {})
+    end
+
+    it 'runs added alerts' do
+      alerts = mock_existing_alerts
+      added = create_test_alert('name3', 'testquery3', '')
+      expect(dest).to receive(:create_alert).once.and_call_original
+      expect(dest).not_to receive(:remove_alert_by_id).with('3')
+
+      interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2'], added], {})
+    end
+
+    it 'runs updated alerts' do
+      added = create_test_alert('name1', 'testquery3', '')
+      expect(dest).to receive(:create_alert).once.and_call_original
+      expect(dest).not_to receive(:remove_alert_by_id).with('1')
+
+      interferon.update_alerts_on_destination(dest, ['host'], [added], {})
+    end
+
+    it 'deletes old alerts' do
+      alerts = mock_existing_alerts
+      expect(dest).to receive(:remove_alert).with(alerts['name1'])
+      expect(dest).to receive(:remove_alert).with(alerts['name2'])
+
+      interferon.update_alerts_on_destination(dest, ['host'], [], {})
+    end
+
+    it 'deletes duplicate old alerts' do
+      alert1 = mock_alert_json('name1', 'testquery1', '', false, false, [1, 2, 3])
+      alert2 = mock_alert_json('name2', 'testquery2', '')
+      existing_alerts = {'name1' => alert1, 'name2' => alert2}
+      dest = MockDest.new(existing_alerts)
+      allow(dest).to receive(:remove_alert)
+      allow(dest).to receive(:remove_alert_by_id)
+      allow(dest).to receive(:report_stats)
+
+      expect(dest).to receive(:remove_alert).with(existing_alerts['name1'])
+      expect(dest).to receive(:remove_alert).with(existing_alerts['name2'])
+
+      interferon.update_alerts_on_destination(dest, ['host'], [], {})
+    end
+
+    it 'deletes duplicate old alerts when creating new alert' do
+      alert1 = mock_alert_json('name1', 'testquery1', '', false, false, [1, 2, 3])
+      alert2 = mock_alert_json('name2', 'testquery2', '')
+      existing_alerts = {'name1' => alert1, 'name2' => alert2}
+      dest = MockDest.new(existing_alerts)
+      allow(dest).to receive(:report_stats)
+
+      added = create_test_alert('name1', 'testquery1', '')
+
+      expect(dest).to receive(:remove_alert).with(mock_alert_json('name1', 'testquery1', '', false, false, [2, 3]))
+      expect(dest).to receive(:remove_alert).with(existing_alerts['name2'])
+
+      interferon.update_alerts_on_destination(dest, ['host'], [added], {})
+    end
+  end
+
+  def mock_existing_alerts
+    alert1 = mock_alert_json('name1', 'testquery1', '')
+    alert2 = mock_alert_json('name2', 'testquery2', '')
+    {'name1' => alert1, 'name2' => alert2}
+  end
+
+  class MockDest < Interferon::Destinations::Datadog
+    @existing_alerts
+
+    def initialize(the_existing_alerts)
+      @existing_alerts = the_existing_alerts
+    end
+
+    def create_alert(alert, people)
+      name = alert['name']
+      id = [alert['name'][-1]]
+      [name, id]
+    end
+
+    def existing_alerts
+      @existing_alerts
+    end
+  end
+
+  def mock_alert_json(name, datadog_query, message, notify_no_data=false, silenced=false, id=nil)
     { 'name'=> name,
       'query'=> datadog_query,
       'message'=> message,
       'notify_no_data' => notify_no_data,
-      'silenced' => silenced
+      'silenced' => silenced,
+      'id' => id.nil? ? [name[-1]] : id
     }
   end
 

--- a/spec/lib/interferon_spec.rb
+++ b/spec/lib/interferon_spec.rb
@@ -37,33 +37,47 @@ describe Interferon::Interferon do
       expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be true
     end
 
+    it "would be dry run if alert silenced changed" do
+      alert1 = create_test_alert('name1', 'testquery1', 'message1', false, true)
+      alert2 = mock_alert_json('name2', 'testquery2', 'message2', false, false)
+
+      expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be false
+    end
+
+    it "would be dry run if alert notify_no_data changed" do
+      alert1 = create_test_alert('name1', 'testquery1', 'message1', false, false)
+      alert2 = mock_alert_json('name2', 'testquery2', 'message2', true, false)
+
+      expect(Interferon::Interferon.same_alerts(dest, [alert1, []], alert2)).to be false
+    end
+
     it 'dry run does not re-run existing alerts' do
       alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil)
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true)
       expect(dest).not_to receive(:create_alert)
       expect(dest).not_to receive(:remove_alert_by_id)
 
-      interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2']], {}, true)
+      interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2']], {})
     end
 
     it 'dry run runs added alerts' do
       alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil)
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true)
       added = create_test_alert('name3', 'testquery3', '')
       expect(dest).to receive(:create_alert).once.and_call_original
       expect(dest).to receive(:remove_alert_by_id).with('[-dry-run-]name3').once
 
-      interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2'], added], {}, true)
+      interferon.update_alerts_on_destination(dest, ['host'], [alerts['name1'], alerts['name2'], added], {})
     end
 
     it 'dry run runs updated alerts' do
       alerts = mock_existing_alerts
-      interferon = Interferon::Interferon.new(nil,nil,nil,nil)
+      interferon = Interferon::Interferon.new(nil,nil,nil,nil,true)
       added = create_test_alert('name1', 'testquery3', '')
       expect(dest).to receive(:create_alert).once.and_call_original
       expect(dest).to receive(:remove_alert_by_id).with('[-dry-run-]name1').once
 
-      interferon.update_alerts_on_destination(dest, ['host'], [added], {}, true)
+      interferon.update_alerts_on_destination(dest, ['host'], [added], {})
     end
 
     def mock_existing_alerts
@@ -90,11 +104,16 @@ describe Interferon::Interferon do
     end
   end
 
-  def mock_alert_json(name, datadog_query, message)
-    {'name'=> name,'query'=> datadog_query,'message'=> message}
+  def mock_alert_json(name, datadog_query, message, notify_no_data=false, silenced=false)
+    { 'name'=> name,
+      'query'=> datadog_query,
+      'message'=> message,
+      'notify_no_data' => notify_no_data,
+      'silenced' => silenced
+    }
   end
 
-  def create_test_alert(name, datadog_query, message)
+  def create_test_alert(name, datadog_query, message, notify_no_data=false, silenced=false)
     alert_dsl = MockAlertDSL.new
     metric_dsl = MockMetricDSL.new
     metric_dsl.datadog_query(datadog_query)
@@ -102,6 +121,8 @@ describe Interferon::Interferon do
     alert_dsl.name(name)
     alert_dsl.applies(true)
     alert_dsl.message(message)
+    alert_dsl.silenced(silenced)
+    alert_dsl.notify_no_data(notify_no_data)
     notify_dsl = MockNotifyDSL.new
     notify_dsl.groups(['a'])
     alert_dsl.notify(notify_dsl)

--- a/spec/lib/work_hours_helper_spec.rb
+++ b/spec/lib/work_hours_helper_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require "interferon/work_hours_helper"
+
+describe Interferon::WorkHoursHelper do
+  subject { described_class }
+
+  describe ".now_is_work_hour?" do
+    context "when it is a work hour in a work day" do
+      it "return true" do
+        expect(subject.is_work_hour?(
+          Time.parse("Mon Nov 26 9:01:20 PST 2001").utc
+        )).to be_truthy
+        expect(subject.is_work_hour?(
+          Time.parse("Fri Nov 30 16:35:20 PST 2001").utc
+        )).to be_truthy
+      end
+    end
+
+    context "when it is a work hour in a weekend" do
+      it "return false" do
+        expect(subject.is_work_hour?(
+          Time.parse("Sat Nov 24 09:01:20 PST 2001").utc
+        )).to be_falsy
+        expect(subject.is_work_hour?(
+          Time.parse("Sun Nov 25 09:01:20 PST 2001").utc
+        )).to be_falsy
+      end
+    end
+
+    context "when it is not a work hour" do
+      it "return false" do
+        expect(subject.is_work_hour?(
+          Time.parse("Thu Nov 29 08:33:20 PST 2001").utc
+        )).to be_falsy
+        expect(subject.is_work_hour?(
+          Time.parse("Fri Nov 30 17:33:20 PST 2001").utc
+        )).to be_falsy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Collection of updates from 0.0.13->0.0.19

# Changes
* Added more statistics around what is successfully created versus what was intended to be created.
* Improve dry-run mode to track updates and deletions which are part of the difference with respect to Datadog. It now looks at the diff of the message section and keep track of updates seperately from new alerts.
* Dry-run will now output a diff format for alerts
* Track deletions separately from dry-run clean up
* Moved dry-run to the destination module as it simplifies the logic and the output becomes cleaner
* Remove dry-run alerts from known existing alerts during dry-run
* Force dry-run alerts to be silent to prevent false alerts
* Use all available processors to create new alerts. This can drastically speed up syncing with Datadog if there a multiple processors available to use on the system.
* Support aliases in the filesystem group_sources. This will enable groups to have aliases during renaming.
* add method to allow != alert behavior during pst work hours

# Bugfixes
* Delete the duplicate copies of alerts and only retain one version per unique name. This was causing issues for things like muting as there would be multiple copies of the same alert in Datadog
