### PR TITLE
interferon 0.1.3

### DIFF
--- a/interferon.gemspec
+++ b/interferon.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
-  gem.add_runtime_dependency 'dogapi', '~> 1.11', '>= 1.11.1'
+  gem.add_runtime_dependency 'dogapi', '~> 1.27', '>= 1.27.0'
   gem.add_runtime_dependency 'aws-sdk', '~> 1.35', '>= 1.35.1'
   gem.add_runtime_dependency 'dogstatsd-ruby', '~> 1.4', '>= 1.4.1'
   gem.add_runtime_dependency 'diffy', '~> 3.1.0', '>= 3.1.0'

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -96,7 +96,7 @@ module Interferon
       loader = GroupSourcesLoader.new([@alerts_repo_path])
       loader.get_all(sources).each do |source|
         break if @request_shutdown
-        source_groups = source.list_groups
+        source_groups = source.list_groups { groups }
 
         # add all people to groups
         people_count = 0

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end


### PR DESCRIPTION
- Updates dogapi minimum to 1.27.0
- Passes groups to next GroupSource plugin