### PR TITLE
Interferon 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ It accepts the following parameters:
 * `group_sources` -- a list of sources which can return groups of people to alert
 * `host_sources` -- a list of sources which can read inventory systems and return lists of hosts to monitor
 * `destinations` -- a list of alerting providers, which can monitor metrics and dispatch alerts as specified in your alerts dsl files
+* `processes` -- number of processes to run the alert generation on (optional; default is to use all available cores)
 
 For more information, see [config.example.yaml](config.example.yaml) file in this repo.
 

--- a/bin/interferon
+++ b/bin/interferon
@@ -14,10 +14,6 @@ optparse = OptionParser.new do |opts|
     options[:config] = key
   end
 
-  opts.on('-p', '--processes processes', Integer, 'Number of processes to run') do |key|
-    options[:processes] = key
-  end
-
   opts.on('-n', '--dry-run', "Don't update alert destinations") do
     options[:dry_run] = true
   end
@@ -59,7 +55,7 @@ end
 
 ENV['DEBUG'] = '1' if config['verbose_logging']
 
-interferon = Interferon::Interferon.new(config, options[:dry_run], options[:processes])
+interferon = Interferon::Interferon.new(config, options[:dry_run])
 interferon.run
 
 puts 'interferon signaling complete!'

--- a/bin/interferon
+++ b/bin/interferon
@@ -10,11 +10,15 @@ options = {}
 optparse = OptionParser.new do |opts|
   opts.banner = %(Usage: interferon --config /path/to/interferon/config)
 
-  opts.on('-c config', '--config config', String, 'Path to interferon config') do |key, _value|
+  opts.on('-c', '--config config', String, 'Path to interferon config') do |key|
     options[:config] = key
   end
 
-  opts.on('-n', '--dry-run', "Don\'t update alert destinations") do
+  opts.on('-p', '--processes processes', Integer, 'Number of processes to run') do |key|
+    options[:processes] = key
+  end
+
+  opts.on('-n', '--dry-run', "Don't update alert destinations") do
     options[:dry_run] = true
   end
 
@@ -26,7 +30,7 @@ end
 
 def parseconfig(filename)
   begin
-    c = YAML.parse(File.read(filename))
+    config = YAML.parse(File.read(filename))
   rescue Errno::ENOENT => e
     raise ArgumentError, "config file does not exist:\n#{e.inspect}"
   rescue Errno::EACCES => e
@@ -34,7 +38,7 @@ def parseconfig(filename)
   rescue YAML::SyntaxError => e
     raise "config file #{filename} contains invalid YAML:\n#{e.inspect}"
   end
-  c.to_ruby
+  config.to_ruby
 end
 
 # parse command line arguments
@@ -55,13 +59,7 @@ end
 
 ENV['DEBUG'] = '1' if config['verbose_logging']
 
-a = Interferon::Interferon.new(
-  config['alerts_repo_path'],
-  config['group_sources'] || {},
-  config['host_sources'],
-  config['destinations']
-)
-
-a.run(options[:dry_run])
+interferon = Interferon::Interferon.new(config, options[:dry_run], options[:processes])
+interferon.run
 
 puts 'interferon signaling complete!'

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -23,16 +23,13 @@ module Interferon
     # groups_sources is a hash from type => options for each group source
     # host_sources is a hash from type => options for each host source
     # destinations is a similar hash from type => options for each alerter
-    def initialize(config, dry_run = false, processes = nil)
+    def initialize(config, dry_run = false)
       @alerts_repo_path = config['alerts_repo_path']
       @group_sources = config['group_sources'] || {}
       @host_sources = config['host_sources']
       @destinations = config['destinations']
-      @alerts_repo_type = config['alerts_repo_type']
-      @alerts_repo_last_modified = config['alerts_repo_last_modified']
+      @processes = config['processes']
       @dry_run = dry_run
-      @processes = processes
-      @evaluation_errors = []
       @request_shutdown = false
     end
 

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -23,28 +23,28 @@ module Interferon
     # groups_sources is a hash from type => options for each group source
     # host_sources is a hash from type => options for each host source
     # destinations is a similar hash from type => options for each alerter
-    def initialize(alerts_repo_path, groups_sources, host_sources, destinations,
-                   dry_run = false, processes = nil)
-      @alerts_repo_path = alerts_repo_path
-      @groups_sources = groups_sources
-      @host_sources = host_sources
-      @destinations = destinations
+    def initialize(config, dry_run = false, processes = nil)
+      @alerts_repo_path = config['alerts_repo_path']
+      @group_sources = config['group_sources'] || {}
+      @host_sources = config['host_sources']
+      @destinations = config['destinations']
+      @alerts_repo_type = config['alerts_repo_type']
+      @alerts_repo_last_modified = config['alerts_repo_last_modified']
       @dry_run = dry_run
       @processes = processes
       @request_shutdown = false
     end
 
-    def run(dry_run = false)
+    def run
       Signal.trap('TERM') do
         log.info 'SIGTERM received. shutting down gracefully...'
         @request_shutdown = true
       end
-      @dry_run = dry_run
       run_desc = @dry_run ? 'dry run' : 'run'
       log.info "beginning alerts #{run_desc}"
 
       alerts = read_alerts
-      groups = read_groups(@groups_sources)
+      groups = read_groups(@group_sources)
       hosts = read_hosts(@host_sources)
 
       @destinations.each do |dest|

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -32,6 +32,7 @@ module Interferon
       @alerts_repo_last_modified = config['alerts_repo_last_modified']
       @dry_run = dry_run
       @processes = processes
+      @evaluation_errors = []
       @request_shutdown = false
     end
 
@@ -141,22 +142,25 @@ module Interferon
     end
 
     def update_alerts(destinations, hosts, alerts, groups)
+      alerts_queue, error_count = build_alerts_queue(hosts, alerts, groups)
+      raise "Some alerts failed to apply or evaluate for all hosts" if @dry_run && error_count > 0
+
       loader = DestinationsLoader.new([@alerts_repo_path])
       loader.get_all(destinations).each do |dest|
         break if @request_shutdown
         log.info "updating alerts on #{dest.class.name}"
-        update_alerts_on_destination(dest, hosts, alerts, groups)
+        update_alerts_on_destination(dest, hosts, alerts_queue, groups)
       end
     end
 
-    def update_alerts_on_destination(dest, hosts, alerts, groups)
+    def update_alerts_on_destination(dest, hosts, alerts_queue, groups)
       # track some counters/stats per destination
       start_time = Time.new.to_f
 
       # get already-defined alerts
       existing_alerts = dest.existing_alerts
 
-      run_update(dest, hosts, alerts, existing_alerts, groups)
+      run_update(dest, hosts, alerts_queue, existing_alerts, groups)
 
       unless @request_shutdown
         # run time summary
@@ -172,11 +176,12 @@ module Interferon
         dest.report_stats
       end
 
-      raise dest.api_errors.to_s if @dry_run && !dest.api_errors.empty?
+      if @dry_run
+        raise dest.api_errors.to_s unless dest.api_errors.empty?
+      end
     end
 
-    def run_update(dest, hosts, alerts, existing_alerts, groups)
-      alerts_queue = build_alerts_queue(hosts, alerts, groups)
+    def run_update(dest, hosts, alerts_queue, existing_alerts, groups)
       updates_queue = alerts_queue.reject do |_name, alert_people_pair|
         !dest.need_update(alert_people_pair, existing_alerts)
       end
@@ -234,16 +239,20 @@ module Interferon
 
     def build_alerts_queue(hosts, alerts, groups)
       alerts_queue = {}
+      errors_count = 0
+
       # create or update alerts; mark when we've done that
       result = Parallel.map(alerts, in_processes: @processes) do |alert|
         break if @request_shutdown
         alerts_generated = {}
+        alert_generation_error_count = 0
         counters = {
-          errors: 0,
-          evals: 0,
-          applies: 0,
-          hosts: hosts.length,
+          :errors => 0,
+          :evals => 0,
+          :applies => 0,
+          :hosts => hosts.length
         }
+
         last_eval_error = nil
 
         hosts.each do |hostinfo|
@@ -287,12 +296,15 @@ module Interferon
 
         # did the alert fail to evaluate on all hosts?
         if counters[:errors] == counters[:hosts] && !last_eval_error.nil?
-          log.error "alert #{alert} failed to evaluate in the context of all hosts!"
-          log.error "last error on alert #{alert}: #{last_eval_error}"
+          log.error("alert #{alert} failed to evaluate in the context of all hosts!")
+          log.error("last error on alert #{alert}: #{last_eval_error}")
 
           statsd.gauge('alerts.evaluate.failed_on_all', 1, tags: ["alert:#{alert}"])
-          log.debug "alert #{alert}: " \
-                    "error #{last_eval_error}\n#{last_eval_error.backtrace.join("\n")}"
+          log.debug(
+            "alert #{alert}: " \
+            "error #{last_eval_error}\n#{last_eval_error.backtrace.join("\n")}"
+          )
+          alert_generation_error_count += 1
         else
           statsd.gauge('alerts.evaluate.failed_on_all', 0, tags: ["alert:#{alert}"])
         end
@@ -300,17 +312,19 @@ module Interferon
         # did the alert apply to any hosts?
         if counters[:applies] == 0
           statsd.gauge('alerts.evaluate.never_applies', 1, tags: ["alert:#{alert}"])
-          log.warn "alert #{alert} did not apply to any hosts"
+          log.warn("alert #{alert} did not apply to any hosts")
+          alert_generation_error_count += 1
         else
           statsd.gauge('alerts.evaluate.never_applies', 0, tags: ["alert:#{alert}"])
         end
-        alerts_generated
+        [alerts_generated, alert_generation_error_count]
       end
 
-      result.each do |alerts_generated|
-        alerts_queue.merge! alerts_generated
+      result.each do |generated_alerts, alert_generation_error_count|
+        alerts_queue.merge!(generated_alerts)
+        errors_count += alert_generation_error_count
       end
-      alerts_queue
+      [alerts_queue, errors_count]
     end
   end
 end

--- a/lib/interferon/alert.rb
+++ b/lib/interferon/alert.rb
@@ -1,13 +1,10 @@
 module Interferon
-  attr_accessor :counters
-
   class Alert
     def initialize(path)
       @path = path
       @filename = File.basename(path)
 
       @text = File.read(@path)
-      @counters = Hash.new(0)
 
       @dsl = nil
     end

--- a/lib/interferon/alert.rb
+++ b/lib/interferon/alert.rb
@@ -1,10 +1,13 @@
 module Interferon
+  attr_accessor :counters
+
   class Alert
     def initialize(path)
       @path = path
       @filename = File.basename(path)
 
       @text = File.read(@path)
+      @counters = Hash.new(0)
 
       @dsl = nil
     end

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -119,10 +119,10 @@ module Interferon::Destinations
         @stats[:manually_created_alerts] = \
           @existing_alerts.reject { |_n, a| a['message'].include?(ALERT_KEY) }.length
 
-        log.info 'datadog: found %d existing alerts; %d were manually created' % [
-          @existing_alerts.length,
-          @stats[:manually_created_alerts],
-        ]
+        log.info(
+          "datadog: found #{@existing_alerts.length} existing alerts; " \
+          "#{@stats[:manually_created_alerts]} were manually created"
+        )
       end
 
       @existing_alerts
@@ -200,7 +200,7 @@ EOM
       monitor_options = {
         name: alert['name'],
         message: message,
-        options: alert_options
+        options: alert_options,
       }
 
       if @dry_run
@@ -244,7 +244,7 @@ EOM
       monitor_options = {
         name: alert['name'],
         message: message,
-        options: alert_options
+        options: alert_options,
       }
 
       if @dry_run

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -197,13 +197,25 @@ Options:
 EOM
       log.info("creating new alert #{alert['name']}: #{new_alert_text}")
 
-      @dog.monitor(
-        alert['monitor_type'],
-        datadog_query,
+      monitor_options = {
         name: alert['name'],
-        message: @dry_run ? self.class.generate_message(alert, []) : message,
+        message: message,
         options: alert_options
-      )
+      }
+
+      if @dry_run
+        @dog.validate_monitor(
+          alert['monitor_type'],
+          datadog_query,
+          monitor_options
+        )
+      else
+        @dog.monitor(
+          alert['monitor_type'],
+          datadog_query,
+          monitor_options
+        )
+      end
     end
 
     def update_datadog_alert(alert, datadog_query, message, alert_options, existing_alert)
@@ -229,21 +241,23 @@ EOM
       diff = Diffy::Diff.new(existing_alert_text, new_alert_text, context: 1)
       log.info("updating existing alert #{id} (#{alert['name']}):\n#{diff}")
 
+      monitor_options = {
+        name: alert['name'],
+        message: message,
+        options: alert_options
+      }
+
       if @dry_run
-        resp = @dog.monitor(
+        resp = @dog.validate_monitor(
           alert['monitor_type'],
           datadog_query,
-          name: alert['name'],
-          message: self.class.generate_message(alert, []),
-          options: alert_options
+          monitor_options
         )
       elsif self.class.same_monitor_type(alert['monitor_type'], existing_alert['type'])
         resp = @dog.update_monitor(
           id,
           datadog_query,
-          name: alert['name'],
-          message: message,
-          options: alert_options
+          monitor_options
         )
 
         # Unmute existing alerts that have been unsilenced.
@@ -259,9 +273,7 @@ EOM
           resp = @dog.monitor(
             alert['monitor_type'],
             datadog_query,
-            name: alert['name'],
-            message: message,
-            options: alert_options
+            monitor_options
           )
         end
       end
@@ -273,6 +285,7 @@ EOM
         @stats[:alerts_to_be_deleted] += 1
         log.info("deleting alert: #{alert['name']}")
 
+        # Safety to protect aginst accident dry_run deletion
         unless @dry_run
           alert['id'].each do |alert_id|
             resp = @dog.delete_monitor(alert_id)
@@ -288,14 +301,6 @@ EOM
       else
         log.warn("not deleting manually-created alert #{alert['id']} (#{alert['name']})")
       end
-    end
-
-    def remove_alert_by_id(alert_id)
-      # This should only be used by dry-run to clean up created dry-run alerts
-      log.debug("deleting alert, id: #{alert_id}")
-      resp = @dog.delete_monitor(alert_id)
-      code = resp[0].to_i
-      log_datadog_response_code(resp, code, :deleting)
     end
 
     def need_update(alert_people_pair, existing_alerts_from_api)

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -386,7 +386,7 @@ EOM
                     " response was #{resp[0]}:'#{resp[1].inspect}'")
         end
 
-        # unknown (prob. datadog) error:
+      # unknown (prob. datadog) error:
       elsif code > 400 || code == -1
         @stats[:api_unknown_errors] += 1
         unless alert.nil?

--- a/lib/interferon/group_sources/filesystem.rb
+++ b/lib/interferon/group_sources/filesystem.rb
@@ -16,7 +16,7 @@ module Interferon::GroupSources
       @paths.each do |path|
         path = File.expand_path(path)
         unless Dir.exist?(path)
-          log.warn "no such directory #{path} for reading group files"
+          log.warn("no such directory #{path} for reading group files")
           next
         end
 
@@ -24,9 +24,9 @@ module Interferon::GroupSources
           begin
             group = YAML.parse(File.read(group_file))
           rescue YAML::SyntaxError => e
-            log.error "syntax error in group file #{group_file}: #{e}"
+            log.error("syntax error in group file #{group_file}: #{e}")
           rescue StandardError => e
-            log.warn "error reading group file #{group_file}: #{e}"
+            log.warn("error reading group file #{group_file}: #{e}")
           else
             group = group.to_ruby
             if group['people']
@@ -44,7 +44,7 @@ module Interferon::GroupSources
         if groups.include?(group)
           groups[aliased_group] = groups[group]
         else
-          log.warn "Alias not found for #{group} but used by #{aliased_group} in #{group_file}"
+          log.warn("Alias not found for #{group} but used by #{aliased_group} in #{group_file}")
         end
       end
 

--- a/lib/interferon/loaders.rb
+++ b/lib/interferon/loaders.rb
@@ -35,12 +35,12 @@ module Interferon
         options =   source['options'] || {}
 
         if type.nil?
-          log.warn "#{@loader_for} ##{idx} does not have a 'type' set; 'type' is required"
+          log.warn("#{@loader_for} ##{idx} does not have a 'type' set; 'type' is required")
           next
         end
 
         unless enabled
-          log.info "skipping #{@loader_for} #{type} because it's not enabled"
+          log.info("skipping #{@loader_for} #{type} because it's not enabled")
           next
         end
 
@@ -68,9 +68,11 @@ module Interferon
           require full_path
           klass = @module.const_get(class_name)
         rescue LoadError => e
-          log.debug "LoadError looking for #{@loader_for} file #{type} at #{full_path}: #{e}"
+          log.debug("LoadError looking for #{@loader_for} file #{type} at #{full_path}: #{e}")
         rescue NameError => e
-          log.debug "NameError looking for #{@loader_for} class #{class_name} in #{full_path}: #{e}"
+          log.debug(
+            "NameError looking for #{@loader_for} class #{class_name}  in #{full_path}: #{e}"
+          )
         end
 
         break if klass

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/lib/interferon/destinations/datadog_spec.rb
+++ b/spec/lib/interferon/destinations/datadog_spec.rb
@@ -88,8 +88,8 @@ describe Interferon::Destinations::Datadog do
       datadog.create_alert(mock_alert, mock_people)
     end
 
-    it 'always calls monitor in dry-run' do
-      expect_any_instance_of(Dogapi::Client).to receive(:monitor).and_return([200, ''])
+    it 'calls validate monitor in dry-run' do
+      expect_any_instance_of(Dogapi::Client).to receive(:validate_monitor).and_return([200, ''])
       expect(datadog_dry_run).to receive(:existing_alerts).and_return(mock_response)
       datadog_dry_run.create_alert(mock_alert, mock_people)
     end
@@ -112,14 +112,6 @@ describe Interferon::Destinations::Datadog do
     it 'does not call dogapi delete_monitor when ALERT_KEY is missing' do
       expect_any_instance_of(Dogapi::Client).to_not receive(:delete_monitor)
       datadog.remove_alert(mock_alert)
-    end
-  end
-
-  describe '.remove_alert_by_id' do
-    it 'calls dogapi delete_monitor' do
-      expect_any_instance_of(Dogapi::Client).to receive(:delete_monitor)
-        .with(mock_alert_id).and_return([200, ''])
-      datadog.remove_alert_by_id(mock_alert_id)
     end
   end
 end

--- a/spec/lib/interferon_spec.rb
+++ b/spec/lib/interferon_spec.rb
@@ -71,7 +71,7 @@ describe Interferon::Destinations::Datadog do
   end
 
   context 'dry_run_update_alerts_on_destination' do
-    let(:interferon) { Interferon::Interferon.new({}, true, 0) }
+    let(:interferon) { Interferon::Interferon.new({ 'processes' => 0 }, true) }
 
     before do
       allow_any_instance_of(MockAlert).to receive(:evaluate)
@@ -152,7 +152,7 @@ describe Interferon::Destinations::Datadog do
   end
 
   context 'update_alerts_on_destination' do
-    let(:interferon) { Interferon::Interferon.new({}, false, 0) }
+    let(:interferon) { Interferon::Interferon.new({ 'processes' => 0 }, false) }
 
     before do
       allow_any_instance_of(MockAlert).to receive(:evaluate)


### PR DESCRIPTION
Interferon 0.2.0

- Overhaul the dry-run functionality using the Datadog validation API instead of creating and deleting alerts with the [-dry-run-] prefix.
- Fail dry-run when alert exists that do not apply to any host or errors on all hosts.
- Clean up configuration passing.
- Misc other clean up.