### PR TITLE
[datadog] Add notify.recovery option

### DIFF
--- a/lib/interferon/alert_dsl.rb
+++ b/lib/interferon/alert_dsl.rb
@@ -122,6 +122,10 @@ module Interferon
     def audit(v = nil, &block)
       get_or_set(:@audit, v, block, false)
     end
+
+    def recovery(v = nil, &block)
+      get_or_set(:@recovery, v, block, true)
+    end
   end
 
   class MetricDSL

--- a/spec/lib/interferon/destinations/datadog_spec.rb
+++ b/spec/lib/interferon/destinations/datadog_spec.rb
@@ -114,4 +114,37 @@ describe Interferon::Destinations::Datadog do
       datadog.remove_alert(mock_alert)
     end
   end
+
+  describe '.generate_message' do
+    let(:message) { 'test message' }
+    let(:people) { %w(userA userB) }
+
+    it 'adds the ALERT_KEY to the message' do
+      expect(Interferon::Destinations::Datadog.generate_message(message, people)).to include(
+        Interferon::Destinations::Datadog::ALERT_KEY
+      )
+    end
+
+    it 'adds a mention to people' do
+      expect(Interferon::Destinations::Datadog.generate_message(message, people)).to include(
+        *people.map { |person| "@#{person}" }
+      )
+    end
+
+    it 'does not add ^is_recovery template variable when notify_recovery is true' do
+      expect(
+        Interferon::Destinations::Datadog.generate_message(
+          message, people, notify_recovery: true
+        )
+      ).not_to include('{{^is_recovery}}')
+    end
+
+    it 'adds a ^is_recovery template variable when notify_recovery is false' do
+      expect(
+        Interferon::Destinations::Datadog.generate_message(
+          message, people, notify_recovery: false
+        )
+      ).to include('{{^is_recovery}}')
+    end
+  end
 end


### PR DESCRIPTION
Add notify.recovery to Alert DSL

The default value is true which is the current behavior.
When this value is false, then the mentions that are appended
to the alert message is wrapped around {{^is_recovery}}.
This is a Datadog template variable that will only show the
contents when not in the recovery state.