### PR TITLE
[dsl] Add ability to just evaluate the alert once

### DIFF
--- a/lib/interferon/alert.rb
+++ b/lib/interferon/alert.rb
@@ -14,6 +14,7 @@ module Interferon
     end
 
     def evaluate(hostinfo)
+      return self if @dsl && @dsl.applies == :once
       dsl = AlertDSL.new(hostinfo)
       dsl.instance_eval(@text, @filename, 1)
       @dsl = dsl

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end


### PR DESCRIPTION
Add `:once` as a possible value to `applies`

This will cause alerts to only be evaluated once by interferon.
Some alerts do no need the dynamic attributes provided
by iteration through the sources that interferon provides.
However, it is still useful to track those alerts via interferon.