### PR TITLE
[bugfix] Fix error message to only display files with errors instead of all

### DIFF
--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -148,7 +148,8 @@ module Interferon
     def update_alerts(destinations, hosts, alerts, groups)
       alerts_queue, alert_errors = build_alerts_queue(hosts, alerts, groups)
       if @dry_run && !alert_errors.empty?
-        raise "Alerts failed to apply or evaluate for all hosts: #{alerts.map(&:to_s).join(', ')}"
+        erroneous_alert_files = alerts_errors.map(&:to_s).join(', ')
+        raise "Alerts failed to apply or evaluate for all hosts: #{erroneous_alert_files}"
       end
 
       loader = DestinationsLoader.new([@alerts_repo_path])


### PR DESCRIPTION
Currently, if an alert fails to evaluate or apply to all host sources then
the entire list of alerts is printed out instead of just the one that is
failing.