### PR TITLE
[silenced] Allow silencing via the Datadog UI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 language: ruby
 sudo: false
 cache: bundler
+# Update bundler before proceeding
+# Travis CI uses an old version that may cause a bunch of errors
+before_install: gem install bundler
 script:
 - bundle exec rspec
 - bundle exec rubocop

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,3 +36,4 @@ destinations:
       app_key: "fillmein"
       api_key: "alsomissing"
       api_timeout: 15
+      max_mute_minutes: 20160 # 14 days

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -148,7 +148,7 @@ module Interferon
     def update_alerts(destinations, hosts, alerts, groups)
       alerts_queue, alert_errors = build_alerts_queue(hosts, alerts, groups)
       if @dry_run && !alert_errors.empty?
-        erroneous_alert_files = alerts_errors.map(&:to_s).join(', ')
+        erroneous_alert_files = alert_errors.map(&:to_s).join(', ')
         raise "Alerts failed to apply or evaluate for all hosts: #{erroneous_alert_files}"
       end
 

--- a/lib/interferon/alert.rb
+++ b/lib/interferon/alert.rb
@@ -29,12 +29,6 @@ module Interferon
       @dsl.name(name)
     end
 
-    def silence
-      raise 'This alert has not yet been evaluated' unless @dsl
-
-      @dsl.silenced(true)
-    end
-
     def [](attr)
       raise 'This alert has not yet been evaluated' unless @dsl
 

--- a/lib/interferon/version.rb
+++ b/lib/interferon/version.rb
@@ -1,3 +1,3 @@
 module Interferon
-  VERSION = '0.2.2'.freeze
+  VERSION = '0.2.3'.freeze
 end


### PR DESCRIPTION
Expire mutes after a given threshold
Delete now unused `silence` method in Alert