### PR TITLE
Add support for new_host_delay option

### DIFF
--- a/lib/interferon/alert_dsl.rb
+++ b/lib/interferon/alert_dsl.rb
@@ -95,6 +95,10 @@ module Interferon
       get_or_set(:@evaluation_delay, v, block, nil)
     end
 
+    def new_host_delay(v = nil, &block)
+      get_or_set(:@new_host_delay, v, block, 300)
+    end
+
     def require_full_window(v = nil, &block)
       get_or_set(:@require_full_window, v, block, nil)
     end

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -163,6 +163,10 @@ module Interferon::Destinations
         alert_options[:evaluation_delay] = alert['evaluation_delay']
       end
 
+      unless alert['new_host_delay'].nil?
+        alert_options[:new_host_delay] = alert['new_host_delay']
+      end
+
       unless alert['require_full_window'].nil?
         alert_options[:require_full_window] = alert['require_full_window']
       end
@@ -349,6 +353,7 @@ EOM
         query: alert_api_json['query'].strip,
         message: alert_api_json['message'].strip,
         evaluation_delay: alert_api_json['options']['evaluation_delay'],
+        new_host_delay: alert_api_json['options']['new_host_delay'],
         include_tags: alert_api_json['options']['include_tags'],
         notify_no_data: alert_api_json['options']['notify_no_data'],
         notify_audit: alert_api_json['options']['notify_audit'],
@@ -367,6 +372,7 @@ EOM
           notify_recovery: alert['notify']['recovery']
         ).strip,
         evaluation_delay: alert['evaluation_delay'],
+        new_host_delay: alert['new_host_delay'],
         include_tags: alert['notify']['include_tags'],
         notify_no_data: alert['notify_no_data'],
         notify_audit: alert['notify']['audit'],

--- a/spec/lib/interferon_spec.rb
+++ b/spec/lib/interferon_spec.rb
@@ -89,6 +89,10 @@ describe Interferon::Destinations::Datadog do
       it_behaves_like('alert_option', 'evaluation_delay', nil, 300)
     end
 
+    context 'new_host_delay option' do
+      it_behaves_like('alert_option', 'new_host_delay', 400, 400)
+    end
+
     context 'thresholds option' do
       it_behaves_like('alert_option', 'thresholds', nil, 'critical' => 1)
     end
@@ -305,6 +309,7 @@ describe Interferon::Destinations::Datadog do
 
   DEFAULT_OPTIONS = {
     'evaluation_delay' => nil,
+    'new_host_delay' => 300,
     'notify_audit' => false,
     'notify_no_data' => false,
     'silenced' => {},
@@ -358,6 +363,7 @@ describe Interferon::Destinations::Datadog do
     alert_dsl.no_data_timeframe(options['no_data_timeframe'])
     alert_dsl.notify_no_data(options['notify_no_data'])
     alert_dsl.evaluation_delay(options['evaluation_delay'])
+    alert_dsl.new_host_delay(options['new_host_delay'])
     alert_dsl.require_full_window(options['require_full_window'])
     alert_dsl.thresholds(options['thresholds'])
     alert_dsl.timeout(options['timeout'])


### PR DESCRIPTION
Add support for the `new_host_delay` option in alerts. It allows setting a delay before starting the evaluation of monitor results.

This is useful for delaying the evaluation of service check alerts while an instance is booting up.