### PR TITLE
Allow multiple destinations

### DIFF
--- a/interferon.gemspec
+++ b/interferon.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'parallel', '~> 1.9', '>= 1.9.0'
   gem.add_runtime_dependency 'nokogiri', '< 1.7.0'
   gem.add_runtime_dependency 'tzinfo', '~> 1.2.2', '>= 1.2.2'
+  gem.add_runtime_dependency 'psych', '~> 2.0'
 
   gem.add_development_dependency 'rspec', '~> 3.2'
   gem.add_development_dependency 'pry', '~> 0.10'

--- a/lib/interferon.rb
+++ b/lib/interferon.rb
@@ -75,7 +75,7 @@ module Interferon
           path: 'alert_definitions',
           extention: '*.yml',
           class: AlertYaml,
-        }
+        },
       ]
 
       alert_types.each do |alert_type|
@@ -206,15 +206,14 @@ module Interferon
     end
 
     def run_update(dest, alerts_queue, existing_alerts)
-      updates_queue = alerts_queue.reject do |_name, alert_people_pair|
-        !dest.need_update(alert_people_pair, existing_alerts)
+      dest_name = dest.class.name.split('::').last.downcase
+      updates_queue = alerts_queue.select do |_name, alert_people_pair|
+        alert, _people = alert_people_pair
+        dest_name == alert[:target] && dest.need_update(alert_people_pair, existing_alerts)
       end
 
       # Create alerts in destination
       create_alerts(dest, updates_queue)
-
-      # Do not continue to remove alerts during dry-run
-      return if @dry_run
 
       # Existing alerts are pruned until all that remains are
       # alerts that aren't being generated anymore

--- a/lib/interferon/alert_dsl.rb
+++ b/lib/interferon/alert_dsl.rb
@@ -110,6 +110,10 @@ module Interferon
     def metric(_v = nil)
       @metric ||= MetricDSL.new(@hostinfo)
     end
+
+    def target(v = nil, &block)
+      get_or_set(:@target, v, block, 'datadog')
+    end
   end
 
   class NotifyDSL

--- a/lib/interferon/alert_yaml.rb
+++ b/lib/interferon/alert_yaml.rb
@@ -1,0 +1,117 @@
+module Interferon
+  class AlertYaml < Alert
+    def initialize(path)
+      @path = path
+      @filename = File.basename(path)
+      @text = File.read(@path)
+
+      @data = nil
+      @scope = nil
+      @notify = nil
+    end
+
+    def to_s
+      @filename
+    end
+
+    def evaluate(hostinfo)
+      safe_hostinfo = Hash.new('').merge!(hostinfo)
+      text = string_format(@text, safe_hostinfo)
+      @data = YAML.safe_load(text)
+      @scope = hostinfo
+
+      @data['name'] += ' [Interferon]'
+
+      @notify = {
+        groups: [],
+        people: [],
+      }
+
+      @data['options']['notifiers'].each do |notifier|
+        args = notifier['args']
+        case notifier['type']
+        when 'groups'
+          @notify[:groups].concat(args['groups'])
+        when 'people'
+          @notify[:people].concat(args['people'])
+        end
+      end
+      # return the alert and not the DSL object, which is private
+      self
+    end
+
+    def string_format(string, hash)
+      missing_key_re = /key{(.+)} not found/
+      begin
+        string % hash
+      rescue KeyError => e
+        key_name = missing_key_re.match(e.message)[1]
+        hash[key_name.to_sym] = ''
+        retry
+      end
+    end
+
+    def match_matcher(match_options)
+      match_options.each do |key, value|
+        scope_value = @scope[key.intern]
+        return false unless scope_value && File.fnmatch(value, scope_value)
+      end
+      true
+    end
+
+    def not_match_matcher(match_options)
+      !match_matcher(match_options)
+    end
+
+    def including_matcher(match_options)
+      match_options.each do |key, value|
+        scope_value = @scope[key.intern]
+        return false unless scope_value && value.include?(scope_value)
+      end
+      true
+    end
+
+    def excluding_matcher(match_options)
+      !including_matcher(match_options)
+    end
+
+    def applies?(scope_option)
+      scope_option.each do |matcher, matcher_options|
+        result = case matcher
+                 when 'matches'
+                   match_matcher(matcher_options)
+                 when 'not_matches'
+                   not_match_matcher(matcher_options)
+                 when 'including'
+                   including_matcher(matcher_options)
+                 when 'excluding'
+                   excluding_matcher(matcher_options)
+                 end
+        return false unless result
+      end
+      true
+    end
+
+    def applies
+      return false unless @scope[:source] == @data['scope']
+      @data['scope_options'].each do |scope_option|
+        return true if applies?(scope_option)
+      end
+      false
+    end
+
+    def [](attr)
+      raise 'This alert has not yet been evaluated' unless @data
+      case attr
+      when :applies, 'applies'
+        applies
+      when :notify, 'notify'
+        @notify
+      when :scope, 'scope'
+        @scope
+      else
+        @data[attr.to_s]
+      end
+    end
+  end
+end

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -313,20 +313,22 @@ EOM
         log.info("deleting alert: #{alert['name']}")
 
         # Safety to protect aginst accident dry_run deletion
-        unless @dry_run
-          alert['id'].each do |alert_id|
-            resp = @dog.delete_monitor(alert_id)
-            code = resp[0].to_i
-            log_datadog_response_code(resp, code, :deleting)
-
-            unless code >= 300 || code == -1
-              # assume this was a success
-              @stats[:alerts_deleted] += 1
-            end
-          end
-        end
+        remove_datadog_alert(alert) unless @dry_run
       else
         log.warn("not deleting manually-created alert #{alert['id']} (#{alert['name']})")
+      end
+    end
+
+    def remove_datadog_alert(alert)
+      alert['id'].each do |alert_id|
+        resp = @dog.delete_monitor(alert_id)
+        code = resp[0].to_i
+        log_datadog_response_code(resp, code, :deleting)
+
+        unless code >= 300 || code == -1
+          # assume this was a success
+          @stats[:alerts_deleted] += 1
+        end
       end
     end
 

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -202,9 +202,8 @@ module Interferon::Destinations
         @stats[:alerts_silenced] += 1 unless alert_options[:silenced].empty?
       end
 
-      id = resp[1].nil? ? nil : [resp[1]['id']]
       # lets key alerts by their name
-      [alert['name'], id]
+      alert['name']
     end
 
     def create_datadog_alert(alert, datadog_query, message, alert_options)

--- a/spec/fixtures/files/sample_alert.yml
+++ b/spec/fixtures/files/sample_alert.yml
@@ -1,0 +1,26 @@
+name: '%{application_name} Error Rate'
+description: 'Track NewRelic error rate for %{application_name}'
+
+scope: 'new_relic_application'
+scope_options:
+  - matches:
+      application_name: 'Sample App'
+
+target: 'newrelic'
+target_options:
+  type: 'apm_app_metric'
+  metric: 'error_percentage'
+  enabled: true
+  condition_scope: 'application'
+  terms:
+    - duration: '5'
+      operator: 'above'
+      priority: 'critical'
+      threshold: '0.1'
+      time_function: 'all'
+
+options:
+  notifiers:
+    - type: 'people'
+      args:
+        people: ['alerts@domain.com']

--- a/spec/lib/interferon/alert_yaml_spec.rb
+++ b/spec/lib/interferon/alert_yaml_spec.rb
@@ -1,0 +1,202 @@
+require 'spec_helper'
+require 'interferon/alert_yaml'
+
+describe Interferon::AlertYaml do
+  let(:sample_alert_yml_path) { './spec/fixtures/files/sample_alert.yml' }
+  describe '#initialize' do
+    it 'reads a file' do
+      expect(File).to receive(:read).with(sample_alert_yml_path)
+      Interferon::AlertYaml.new(sample_alert_yml_path)
+    end
+  end
+
+  context 'with hostinfo' do
+    let(:hostinfo) { { application_name: 'Sample Application' } }
+
+    before do
+      @alert_yml = Interferon::AlertYaml.new(sample_alert_yml_path)
+    end
+
+    describe '#evaluate' do
+      it 'loads a YAML file' do
+        expect(YAML).to receive(:safe_load).and_call_original
+        @alert_yml.evaluate(hostinfo)
+      end
+
+      it 'adds interferon tag to name' do
+        alert = @alert_yml.evaluate(hostinfo)
+        expect(alert['name'].end_with?('[Interferon]')).to be true
+      end
+
+      describe '#match_matcher' do
+        it 'matches a positive glob' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.match_matcher('role' => 'test-*')).to be true
+        end
+
+        it 'matches a positive exact match' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.match_matcher('role' => 'test-app')).to be true
+        end
+
+        it 'matches multiple postive matches' do
+          hostinfo = { role: 'test-app', region: 'a' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.match_matcher('role' => 'test-*', 'region' => 'a')).to be true
+        end
+
+        it 'does not match negative matches' do
+          hostinfo = { role: 'test' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.match_matcher('role' => 'test-app')).to be false
+        end
+
+        it 'does not match multiple matches when one is missing from hostinfo' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.match_matcher('role' => 'test-*', 'region' => 'a')).to be false
+        end
+      end
+
+      describe '#not_match_matcher' do
+        it 'does not match a positive glob' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.not_match_matcher('role' => 'test-*')).to be false
+        end
+
+        it 'does not match a positive exact match' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.not_match_matcher('role' => 'test-app')).to be false
+        end
+
+        it 'does not match multiple positive matches' do
+          hostinfo = { role: 'test-app', region: 'a' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.not_match_matcher('role' => 'test-*', 'region' => 'a')).to be false
+        end
+
+        it 'match when negative match' do
+          hostinfo = { role: 'test' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.not_match_matcher('role' => 'test-app')).to be true
+        end
+
+        it 'match when one of multiple matches is missing from hostinfo' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.not_match_matcher('role' => 'test-*', 'region' => 'a')).to be true
+        end
+      end
+
+      describe '#including_matcher' do
+        it 'match a positive include' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.including_matcher('role' => ['test-app'])).to be true
+        end
+
+        it 'match when multiple positive includes' do
+          hostinfo = { role: 'test-app',  region: 'a' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.including_matcher('role' => ['test-app'], 'region' => 'a')).to be true
+        end
+
+        it 'does not match negative include' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.including_matcher('role' => ['test'])).to be false
+        end
+
+        it 'does not match when one of multiple includes is missing from hostinfo' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.including_matcher('role' => ['test-app'], 'region' => 'a')).to be false
+        end
+      end
+
+      describe '#not_including_matcher' do
+        it 'match when negative includes' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.excluding_matcher('role' => ['test'])).to be true
+        end
+
+        it 'match when one of multiple includes is missing from hostinfo' do
+          hostinfo = { role: 'test' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.excluding_matcher('role' => ['test'], 'region' => 'a')).to be true
+        end
+
+        it 'does not match positive includes' do
+          hostinfo = { role: 'test-app' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.excluding_matcher('role' => ['test-app'])).to be false
+        end
+
+        it 'does not match when multiple positive includes' do
+          hostinfo = { role: 'test-app',  region: 'a' }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.excluding_matcher('role' => ['test-app'], 'region' => 'a')).to be false
+        end
+      end
+
+      describe '#applies?' do
+        it 'returns true when there are no scope options' do
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.applies?({})).to be true
+        end
+
+        it 'runs the approprate matcher' do
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert).to receive(:match_matcher).once
+          alert.applies?(
+            'matches' => { 'application_name' => 'Sample App' }
+          )
+        end
+
+        it 'runs the approprate matchers' do
+          hostinfo = {
+            source: 'new_relic_application',
+            application_name: 'Sample App',
+          }
+          alert = @alert_yml.evaluate(hostinfo)
+          allow(alert).to receive(:match_matcher).once.and_return(true)
+          expect(alert).to receive(:including_matcher).once
+          alert.applies?(
+            'matches' => { 'application_name' => 'Sample App' },
+            'including' => { 'application_name' => ['Sample App'] }
+          )
+        end
+      end
+
+      describe '#applies' do
+        it 'return false if source does not match' do
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.applies).to be false
+        end
+
+        it 'return true if source and application matches' do
+          hostinfo = {
+            source: 'new_relic_application',
+            application_name: 'Sample App',
+          }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.applies).to be true
+        end
+
+        it 'return false if source matches and application does not match' do
+          hostinfo = {
+            source: 'new_relic_application',
+            application_name: 'Sample Application',
+          }
+          alert = @alert_yml.evaluate(hostinfo)
+          expect(alert.applies).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/interferon_spec.rb
+++ b/spec/lib/interferon_spec.rb
@@ -167,7 +167,7 @@ describe Interferon::Destinations::Datadog do
     end
 
     it 'does not delete old alerts' do
-      expect(dest).to_not receive(:remove_alert)
+      expect(dest).to_not receive(:remove_datadog_alert)
       alerts_queue, _error_count = interferon.build_alerts_queue(['host'], [], {})
 
       interferon.update_alerts_on_destination(dest, alerts_queue)
@@ -183,7 +183,7 @@ describe Interferon::Destinations::Datadog do
 
       alerts_queue, _error_count = interferon.build_alerts_queue(['host'], [], {})
 
-      expect(dest).to_not receive(:remove_alert)
+      expect(dest).to_not receive(:remove_datadog_alert)
 
       interferon.update_alerts_on_destination(dest, alerts_queue)
     end
@@ -199,7 +199,7 @@ describe Interferon::Destinations::Datadog do
       added = create_test_alert('name1', 'testquery1', '')
       alerts_queue, _error_count = interferon.build_alerts_queue(['host'], [added], {})
 
-      expect(dest).to_not receive(:remove_alert)
+      expect(dest).to_not receive(:remove_datadog_alert)
 
       interferon.update_alerts_on_destination(dest, alerts_queue)
     end
@@ -365,6 +365,7 @@ describe Interferon::Destinations::Datadog do
     alert_dsl.name(name)
     alert_dsl.applies(true)
     alert_dsl.message(message)
+    alert_dsl.target('mockdest')
 
     alert_dsl.no_data_timeframe(options['no_data_timeframe'])
     alert_dsl.notify_no_data(options['notify_no_data'])


### PR DESCRIPTION
Adds target to Alert DSL to target destinations
Allow for reading YAML based definitions from alerts_definitions directory
Abort dry-run on file reading errors