### PR TITLE
[lint] Pin rubocop to 0.56.x & fix issues

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,7 +89,10 @@ Style/FormatString:
   - sprintf
   - percent
 
-Style/MethodMissing:
+Style/MethodMissingSuper:
+  Enabled: false
+
+Style/MissingRespondToMissing:
   Enabled: false
 
 Style/MixinUsage:

--- a/interferon.gemspec
+++ b/interferon.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'pry', '~> 0.10'
   gem.add_development_dependency 'rspec', '~> 3.2'
-  gem.add_development_dependency 'rubocop', '~> 0.55'
+  gem.add_development_dependency 'rubocop', '~> 0.56.0'
 end

--- a/lib/interferon/loaders.rb
+++ b/lib/interferon/loaders.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module Interferon

--- a/spec/fixtures/loaders2/test_sources/secondary_source.rb
+++ b/spec/fixtures/loaders2/test_sources/secondary_source.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module Interferon::TestSources

--- a/spec/helpers/loader_helper.rb
+++ b/spec/helpers/loader_helper.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 ### some helpers to make this work ###

--- a/spec/lib/work_hours_helper_spec.rb
+++ b/spec/lib/work_hours_helper_spec.rb
@@ -11,10 +11,10 @@ describe Interferon::WorkHoursHelper do
       it 'return true' do
         expect(subject.is_work_hour?(
                  Time.parse('Mon Nov 26 9:01:20 PST 2001').utc
-        )).to be_truthy
+               )).to be_truthy
         expect(subject.is_work_hour?(
                  Time.parse('Fri Nov 30 16:35:20 PST 2001').utc
-        )).to be_truthy
+               )).to be_truthy
       end
     end
 
@@ -22,10 +22,10 @@ describe Interferon::WorkHoursHelper do
       it 'return false' do
         expect(subject.is_work_hour?(
                  Time.parse('Sat Nov 24 09:01:20 PST 2001').utc
-        )).to be_falsy
+               )).to be_falsy
         expect(subject.is_work_hour?(
                  Time.parse('Sun Nov 25 09:01:20 PST 2001').utc
-        )).to be_falsy
+               )).to be_falsy
       end
     end
 
@@ -33,10 +33,10 @@ describe Interferon::WorkHoursHelper do
       it 'return false' do
         expect(subject.is_work_hour?(
                  Time.parse('Thu Nov 29 08:33:20 PST 2001').utc
-        )).to be_falsy
+               )).to be_falsy
         expect(subject.is_work_hour?(
                  Time.parse('Fri Nov 30 17:33:20 PST 2001').utc
-        )).to be_falsy
+               )).to be_falsy
       end
     end
   end


### PR DESCRIPTION
Having rubocop pinned to any 0.x version was causing inconsistent behavior, including the travis build to fail.

Rubocop 0.58.x is latest but drops support for ruby 2.1. I don't have a use case for ruby 2.1 or care about dropping support for it, but that's not my call.

Rubocop 0.57 has a bug (with an unreleased fix, https://github.com/rubocop-hq/rubocop/pull/6003) that impacts this project.

So pinned to 0.56.x for now.