### PR TITLE
Allow tags to be added to monitors

### DIFF
--- a/lib/interferon/alert_dsl.rb
+++ b/lib/interferon/alert_dsl.rb
@@ -132,6 +132,10 @@ module Interferon
     def target(v = nil, &block)
       get_or_set(:@target, v, block, 'datadog')
     end
+
+    def tags(v = nil, &block)
+      get_or_set(:@tags, v, block, [])
+    end
   end
 
   class NotifyDSL

--- a/spec/lib/interferon/destinations/datadog_spec.rb
+++ b/spec/lib/interferon/destinations/datadog_spec.rb
@@ -43,6 +43,7 @@ describe Interferon::Destinations::Datadog do
       'metric' => { 'datadog_query' => 'avg:metric{*}' },
       'silenced' => {},
       'notify' => {},
+      'tags' => %w[foo bar],
     }
   end
   let(:mock_people) { %w[foo bar baz] }
@@ -53,6 +54,7 @@ describe Interferon::Destinations::Datadog do
         'name' => 'Test Alert',
         'message' => 'Test Message',
         'query' => 'avg:metric{*}',
+        'tags' => %w[foo bar],
         'options' => {
           'silenced' => {},
         },


### PR DESCRIPTION
This commit adds the ability to add tags to monitors.

This should make it easier to use the monitor rollup view in dashboards
and stuff.

Added some new simple test cases, which I think cover everything, but
please let me know if I am missing anything!

This a continuation of #41, but fixed for a botched merge