### PR TITLE
Get All Monitors: Use monitor id offset

### DIFF
--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -550,7 +550,7 @@ Options:
           break
         end
 
-        log.info("Failed to retrieve end monitor from datadog. #{code}: #{resp[1].inspect}")
+        log.info("Failed to retrieve end monitor from datadog. #{code}: #{monitors.inspect}")
       end
 
       raise 'Unable to find last monitor id' if end_monitor.nil?

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -83,7 +83,7 @@ module Interferon::Destinations
     end
 
     def _fetch_existing_alerts_boundaries
-      # we need to
+      # we need to obtain the monitor id boundary conditions
       start_monitor, end_monitor = nil, nil
 
       # Get first monitor

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -82,102 +82,52 @@ module Interferon::Destinations
       [message, alert_key, mentions].flatten.join("\n")
     end
 
-    def _fetch_existing_alerts_boundaries
-      # we need to obtain the monitor id boundary conditions
-      start_monitor, end_monitor = nil, nil
-
-      # Get first monitor
-      successful = false
-      @retries.downto(0) do
-        options = {page_size: 1, sort: "ASC"}
-        resp = @dog.get_all_monitors(options)
-        code = resp[0].to_i
-        if code != 200
-          log.info("Failed to retrieve start monitor from datadog. #{code}: #{resp[1].inspect}")
-        else
-          if resp[1].length >= 1
-            start_monitor = resp[1][0]
-          end
-          successful = true
-          break
-        end
-      end
-      unless successful
-        raise "Unable to find first monitor id"
-      end
-
-      # Get last monitor
-      successful = false
-      @retries.downto(0) do
-        options = {page_size: 1, sort: "DESC"}
-        resp = @dog.get_all_monitors(options)
-        code = resp[0].to_i
-        if code != 200
-          log.info("Failed to retrieve end monitor from datadog. #{code}: #{resp[1].inspect}")
-        else
-          if resp[1].length >= 1
-            end_monitor = resp[1][0]
-          end
-          successful = true
-          break
-        end
-      end
-      unless successful
-        raise "Unable to find last monitor id"
-      end
-      return start_monitor, end_monitor
-    end
-
     def fetch_existing_alerts
       alerts = Queue.new
-      has_more = true
-      start_monitor, end_monitor = _fetch_existing_alerts_boundaries
-      if start_monitor.nil? || end_monitor.nil?
-        raise 'Retries exceeded for fetching data from datadog.'
-      end
+      start_monitor, end_monitor = fetch_existing_alerts_boundaries
 
-      # edge case where they are equal
-      if start_monitor['id'] == end_monitor['id']
-        return [start_monitor]
-      end
+      # Edge case where they are equal.
+      return [start_monitor] if start_monitor['id'] == end_monitor['id']
 
-      # another easy edge case when the span is like: monitor ids: [1, 2]
-      if end_monitor['id'] - start_monitor['id'] == 1
-        return [start_monitor, end_monitor]
-      end
+      # Another easy edge case when the span is like: monitor ids: [1, 2]
+      return [start_monitor, end_monitor] if end_monitor['id'] - start_monitor['id'] == 1
 
-      # note: inclusive range is important here.
-      id_range = (start_monitor['id']...end_monitor['id'])
+      # Note: inclusive range is important here.
+      range = (start_monitor['id']...end_monitor['id'])
 
-      # split this in divide and conquer-style
-      # build the ranges to iterate on in parallel to merge.
-      # aka build a list of queries for `id_offset=<id>` for which we can run concurrent requests with consistent
-      # latency characteristics.
+      # Split this in divide and conquer-style. Build the ranges to iterate on in parallel to merge.
+      # Build a list of queries for `id_offset=<id>` for which we can run concurrent requests with
+      # consistent latency characteristics.
       queries = []
-      range.step(@page_size) { |i|
-        queries.push(i)
-      }
+
+      range.step(@page_size) { |i| queries.push(i) }
       Parallel.map(queries, in_threads: @concurrency) do |start_monitor_id|
         successful = false
         @retries.downto(0) do
-          options = {page_size: @page_size, id_offset: start_monitor_id, sort: "ASC"}
-          resp = @dog.get_all_monitors(options)
-          code = resp[0].to_i
-          if code != 200
-            log.info("Failed to retrieve existing alerts from datadog on id_offset=#{start_monitor_id} page_size=#{@page_size}. #{code}: #{resp[1].inspect}")
-          else
-            alerts_page = resp[1]
-            alerts_page.map { |alert|
-              alerts.push(alert)
-            }
+          options = { page_size: @page_size, id_offset: start_monitor_id, sort: 'ASC' }
+          code, alerts_page = @dog.get_all_monitors(options)
+
+          if code == 200
+            alerts_page.each { |alert| alerts.push(alert) }
             successful = true
             break
           end
+
+          log.info(
+            <<-LOG_LINE
+              Failed to retrieve existing alerts from datadog on id_offset=#{start_monitor_id}
+              page_size=#{@page_size}. #{code}: #{alerts_page.inspect}
+            LOG_LINE
+          )
         end
-        unless successful
-          # Out of retries
-          raise "Retries exceeded for fetching data from datadog on id_offset=#{start_monitor_id} page_size=#{@page_size}"
-        end
+
+        next if successful
+
+        # Out of retries
+        raise <<-EXCEPTION_LINE
+          Retries exceeded for fetching data from datadog on id_offset=#{start_monitor_id}
+          page_size=#{@page_size}
+        EXCEPTION_LINE
       end
 
       Array.new(alerts.size) { alerts.pop }
@@ -566,6 +516,46 @@ Options:
 
       sleep(2**retries * @retry_base_delay)
       retryable(retries + 1, &block)
+    end
+
+    private
+
+    def fetch_existing_alerts_boundaries
+      # We need to obtain the monitor id boundary conditions.
+      start_monitor = nil
+      end_monitor = nil
+
+      # Get the first monitor.
+      @retries.downto(0) do
+        options = { page_size: 1, sort: 'ASC' }
+        code, monitors = @dog.get_all_monitors(options)
+
+        if code == 200 && !monitors.empty?
+          start_monitor = monitors[0]
+          break
+        end
+
+        log.info("Failed to retrieve start monitor from datadog. #{code}: #{monitors.inspect}")
+      end
+
+      raise 'Unable to find first monitor' if start_monitor.nil?
+
+      # Get the last monitor.
+      @retries.downto(0) do
+        options = { page_size: 1, sort: 'DESC' }
+        code, monitors = @dog.get_all_monitors(options)
+
+        if code == 200 && !monitors.empty?
+          end_monitor = monitors[0]
+          break
+        end
+
+        log.info("Failed to retrieve end monitor from datadog. #{code}: #{resp[1].inspect}")
+      end
+
+      raise 'Unable to find last monitor id' if end_monitor.nil?
+
+      [start_monitor, end_monitor]
     end
   end
 end

--- a/lib/interferon/destinations/datadog.rb
+++ b/lib/interferon/destinations/datadog.rb
@@ -85,16 +85,12 @@ module Interferon::Destinations
     def fetch_existing_alerts
       alerts = Queue.new
       has_more = true
-      last_monitor_id = nil
+      last_monitor_id = 0
 
-      Parallel.map_with_index(-> { has_more || Parallel::Stop },
-                              in_threads: @concurrency) do |_, page|
+      while has_more do
         successful = false
         @retries.downto(0) do
-          options = {page_size: @page_size}
-          unless last_monitor_id.nil?
-            options['id_offset'] = last_monitor_id
-          end
+          options = {page_size: @page_size, id_offset: last_monitor_id}
           resp = @dog.get_all_monitors(options)
           code = resp[0].to_i
           if code != 200

--- a/spec/lib/interferon/destinations/datadog_spec.rb
+++ b/spec/lib/interferon/destinations/datadog_spec.rb
@@ -63,9 +63,29 @@ describe Interferon::Destinations::Datadog do
     }
   end
 
+  let(:mock_alerts) do
+    (0..100).map { |i| mock_alert.merge('id' => i) }
+  end
+
+  let(:mock_last_alert) do
+    {
+      'id' => mock_alert_id + 2,
+      'name' => 'Test Alert',
+      'message' => 'Test Message',
+      'metric' => { 'datadog_query' => 'avg:metric{*}' },
+      'silenced' => {},
+      'notify' => {},
+      'tags' => %w[foo bar],
+    }
+  end
+
   describe '.fetch_existing_alerts' do
     it 'calls dogapi get_all_monitors' do
-      expect_any_instance_of(Dogapi::Client).to receive(:get_all_monitors).and_return([200, []])
+      expect_any_instance_of(Dogapi::Client).to receive(:get_all_monitors).and_return(
+        [200, [mock_alerts[0]]],
+        [200, [mock_alerts[-1]]],
+        [200, mock_alerts]
+      )
       datadog.fetch_existing_alerts
     end
   end


### PR DESCRIPTION
This changes the pagination method to be a bit more efficient at the scale that Airbnb operates monitors. While it's true that the monitor id distribution will very unlikely be evenly distributed, we should see more consistent latency with this pagination method at large scale regardless of the number of monitors configured. It requires at minimum 3 API calls (assuming closely bunched monitor ids under with a count under the page size, and might be a tad inefficient for users with this configuration. Though I think the trade off for knowing this will scale with needs is worth it. We could of course wrap this in a config flag also if that's preferred.

---

Maybe a separate discussion/issue:

After looking at interferon though I think it could benefit from storing the created monitor ID in some local storage and/or query by name similar to the way terraform behaves. (I will not get into the debate of which is a better tool, nor am discounting either tool) - while this would add a bit of additional complexity, we can see that terraform management of monitors does scale well. 

A TLDR of how it does a diff
- As monitors are created the monitor_id is stored in a statefile
- When syncing it first checks by id if the monitor exists (this is a very fast OP)
  - If exists, then compare the diff similar to interferon and update/(delete && create) as needed.
   - If not, then query by (name), if a match is found then, re-run the above step